### PR TITLE
Adjust stool frequency wording

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2443,6 +2443,7 @@ export default function HomePage() {
                           type="number"
                           min={0}
                           step={1}
+                          placeholder="0 (kein Stuhlgang)"
                           value={dailyDraft.urinary?.freqPerDay ?? ""}
                           onChange={(event) =>
                             setDailyDraft((prev) => ({

--- a/lib/terms.ts
+++ b/lib/terms.ts
@@ -64,7 +64,7 @@ export const TERMS = {
   awakenings: { label: "Nächtliches Erwachen", help: "Wie oft aufgewacht?" },
   bristol: { label: "Stuhlform (Bristol 1–7)", help: "Bildskala von hart (1) bis flüssig (7)" },
   bowelPain: { label: "Schmerz beim Stuhlgang (0–10)", help: "Schmerzstärke" },
-  urinary_freq: { label: "Toilettengänge/Tag", help: "Wie oft urinieren?" },
+  urinary_freq: { label: "Stuhlgang pro Tag", help: "Wie oft Stuhlgang? 0 = kein Stuhlgang" },
   urinary_urgency: { label: "Harndrang (0–10)", help: "Starker Drang?" },
   urinary_pain: { label: "Schmerz beim Wasserlassen (0–10)", help: "Brennen/Stechen?" },
   fsfi: { label: "Sexuelle Funktion (FSFI)", help: "Kurzfragebogen zur Sexualität" },

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -207,7 +207,7 @@ export function validateDailyEntry(entry: DailyEntry): ValidationIssue[] {
     if (freqPerDay !== undefined && (!Number.isInteger(freqPerDay) || freqPerDay < 0)) {
       issues.push({
         path: "urinary.freqPerDay",
-        message: "Miktionen/Tag müssen als nicht-negative Ganzzahl erfasst werden.",
+        message: "Stuhlgänge/Tag müssen als nicht-negative Ganzzahl erfasst werden.",
       });
     }
     if (urgency !== undefined && !intRange(urgency, 0, 10)) {


### PR DESCRIPTION
## Summary
- rename the stool frequency term to "Stuhlgang pro Tag" with updated help text and placeholder
- update the validation message to talk about Stuhlgänge instead of Miktionen

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f1e91e70cc832aad0d69655e67aaa9