### PR TITLE
Style saved day overlays and disabled button state

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3348,7 +3348,7 @@ export default function HomePage() {
                     {cycleOverlay.map((row) => (
                       <div
                         key={row.cycleDay}
-                        className="flex items-center justify-between rounded border border-rose-100 bg-rose-50 px-2 py-1"
+                        className="flex items-center justify-between rounded border border-amber-100 bg-amber-50 px-2 py-1"
                       >
                         <span className="font-semibold text-rose-800">ZT {row.cycleDay}</span>
                         <span>{TERMS.nrs.label}: {row.painAvg.toFixed(1)}</span>
@@ -3375,7 +3375,7 @@ export default function HomePage() {
                 <Section title="Wochentag-Overlay" description="Durchschnittlicher NRS nach Wochentag">
                   <div className="grid grid-cols-2 gap-2 text-xs text-rose-700 sm:grid-cols-4">
                     {weekdayOverlay.map((row) => (
-                      <div key={row.weekday} className="rounded border border-rose-100 bg-rose-50 px-2 py-1">
+                      <div key={row.weekday} className="rounded border border-amber-100 bg-amber-50 px-2 py-1">
                         <p className="font-semibold text-rose-800">{row.weekday}</p>
                         <p>{TERMS.nrs.label}: {row.painAvg.toFixed(1)}</p>
                       </div>

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -28,7 +28,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       <button
         ref={ref}
         className={cn(
-          "inline-flex items-center justify-center gap-1 transition-colors focus-visible:outline-none",
+          "inline-flex items-center justify-center gap-1 transition-colors focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50",
           variantStyles[variant],
           sizeStyles[size],
           className


### PR DESCRIPTION
## Summary
- grey out disabled buttons so the "Tagesdaten speichern" action visibly deactivates
- switch the cycle and weekday overlay rows to a pale amber background to highlight stored days

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f1fcc72014832a9f63cf0a07a2537a