### PR TITLE
Adjust page background for saved daily entries

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -11,6 +11,7 @@ body {
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   background-color: var(--endo-bg);
   color: #111827;
+  transition: background-color 0.3s ease;
 }
 
 button:focus-visible,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -122,6 +122,9 @@ const HEAVY_BLEED_PBAC = 100;
 
 const isHeavyBleedToday = (entry: DailyEntry) => (entry.bleeding?.pbacScore ?? 0) >= HEAVY_BLEED_PBAC;
 
+const DEFAULT_PAGE_BG = "#fff1f2";
+const SAVED_PAGE_BG = "#fff7ed";
+
 const EHP5_ITEMS = [
   "Schmerz schränkt Alltagstätigkeiten ein",
   "Arbeit oder Studium litten unter Beschwerden",
@@ -883,6 +886,14 @@ export default function HomePage() {
     () => dailyEntries.some((entry) => entry.date === dailyDraft.date),
     [dailyEntries, dailyDraft.date]
   );
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.style.setProperty("--endo-bg", hasEntryForSelectedDate ? SAVED_PAGE_BG : DEFAULT_PAGE_BG);
+    return () => {
+      root.style.setProperty("--endo-bg", DEFAULT_PAGE_BG);
+    };
+  }, [hasEntryForSelectedDate]);
 
   const selectedDateLabel = useMemo(() => {
     const parsed = parseIsoDate(dailyDraft.date);


### PR DESCRIPTION
## Summary
- change the global page background color when the selected day already has stored data to make saved entries easier to identify
- add a smooth transition to the body background so the highlight change feels subtle

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f202514ea8832a870704a499a38723