### PR TITLE
Make finished cards background lighter

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5,7 +5,7 @@
 :root {
   --endo-accent: #e11d48;
   --endo-bg: #fff1f2;
-  --section-card-completed-bg: #fef9c3;
+  --section-card-completed-bg: #fffbeb;
   --section-card-completed-border: #facc15;
 }
 


### PR DESCRIPTION
## Summary
- lighten the background color used for completed section cards to make the yellow highlight subtler

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f24a9e76dc832a9776d1771924860f