### PR TITLE
Add optional ovulation pain question to pain board

### DIFF
--- a/lib/terms.ts
+++ b/lib/terms.ts
@@ -14,6 +14,12 @@ export const TERMS = {
   },
   painQuality: { label: "Wie fühlt sich der Schmerz an?", help: "Mehrfachauswahl, z. B. krampfend, stechend" },
   bodyMap: { label: "Körperkarte", help: "Tippe an, wo es weh tut" },
+  ovulationPain: {
+    label: "Vermuteter Eisprungschmerz?",
+    tech: "Mittelschmerz",
+    help: "Seitlicher Schmerz rund um den Eisprung",
+    optional: true,
+  },
   bleeding_active: {
     label: "Periode aktiv?",
     tech: "Aktive Menstruationsblutung",

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -44,6 +44,11 @@ export interface DailyEntry {
     bbtCelsius?: number; // optional, Hilfsmittel
   };
 
+  ovulationPain?: {
+    side?: "links" | "rechts" | "beidseitig" | "unsicher";
+    intensity?: number;
+  };
+
   urinaryOpt?: {
     urgency?: number;
     leaksCount?: number;

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -96,6 +96,26 @@ export function validateDailyEntry(entry: DailyEntry): ValidationIssue[] {
     issues.push({ path: "painMapRegionIds", message: "Schmerzorte müssen als Liste gespeichert werden." });
   }
 
+  if (entry.ovulationPain) {
+    const { side, intensity } = entry.ovulationPain;
+    const allowedSides = new Set(["links", "rechts", "beidseitig", "unsicher"]);
+    if (side !== undefined && !allowedSides.has(side)) {
+      issues.push({ path: "ovulationPain.side", message: "Bitte Seite Links/Rechts/Beidseitig/Unsicher wählen." });
+    }
+    if (side === undefined && intensity !== undefined) {
+      issues.push({
+        path: "ovulationPain.side",
+        message: "Bitte zuerst eine Seite auswählen oder Intensität entfernen.",
+      });
+    }
+    if (intensity !== undefined && !intRange(intensity, 0, 10)) {
+      issues.push({
+        path: "ovulationPain.intensity",
+        message: "Intensität muss als ganze Zahl zwischen 0 und 10 erfasst werden.",
+      });
+    }
+  }
+
   if (entry.bleeding.isBleeding) {
     if (!nonNegative(entry.bleeding.pbacScore)) {
       issues.push({


### PR DESCRIPTION
## Summary
- add an ovulation pain question under the body map with side selection and intensity slider
- store, validate, and normalize the new ovulation pain data across imports and exports
- register the Mittelschmerz terminology so the new field appears with contextual help

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f3f3260b7c832aba36dea8f22fef64