### PR TITLE
Reset daily draft when a new day starts

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1166,6 +1166,17 @@ export default function HomePage() {
   );
 
   useEffect(() => {
+    if (!storageReady) return;
+    if (isDailyDirty) return;
+    if (dailyDraft.date >= today) return;
+    const hasDraftEntry = dailyEntries.some((entry) => entry.date === dailyDraft.date);
+    if (hasDraftEntry) return;
+    const next = createEmptyDailyEntry(today);
+    setDailyDraft(next);
+    setLastSavedDailySnapshot(next);
+  }, [storageReady, isDailyDirty, dailyDraft.date, dailyEntries, today]);
+
+  useEffect(() => {
     if (typeof navigator === "undefined" || !("storage" in navigator) || !navigator.storage) {
       setPersisted(null);
       setPersistWarning("Persistent Storage API nicht verfügbar.");


### PR DESCRIPTION
## Summary
- add an effect to refresh the daily draft once storage is ready and the current draft is stale

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f3fbbee1b4832ab33b2161f7cb7101