### PR TITLE
Add iOS standalone PWA metadata

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,15 @@ export const metadata: Metadata = {
   description: "Minimalistische Endometriose-Tracking App",
   manifest: "/manifest.webmanifest",
   themeColor: "#f43f5e",
+  icons: {
+    icon: "/favicon.svg",
+    apple: "/apple-touch-icon.png",
+  },
+  appleWebApp: {
+    capable: true,
+    statusBarStyle: "black-translucent",
+    title: "EndoTrack",
+  },
 };
 
 export default function RootLayout({


### PR DESCRIPTION
## Summary
- add Apple web app metadata and icons configuration to enable standalone mode on iOS

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f403d38380832a90b2fcce5766228a