### PR TITLE
Adjust cycle day selection for unsaved drafts

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1322,7 +1322,9 @@ export default function HomePage() {
     const entries = dailyEntries.slice();
     const draftIndex = entries.findIndex((entry) => entry.date === dailyDraft.date);
     if (draftIndex >= 0) {
-      entries[draftIndex] = dailyDraft;
+      if (isDailyDirty) {
+        entries[draftIndex] = dailyDraft;
+      }
     } else {
       entries.push(dailyDraft);
     }
@@ -1353,7 +1355,7 @@ export default function HomePage() {
       previousBleeding = isBleeding;
     }
     return cycleDay;
-  }, [dailyEntries, dailyDraft]);
+  }, [dailyEntries, dailyDraft, isDailyDirty]);
 
   const canGoToNextDay = useMemo(() => dailyDraft.date < today, [dailyDraft.date, today]);
 


### PR DESCRIPTION
## Summary
- stop overwriting persisted daily entries with the draft when the draft matches saved data
- keep using the draft entry when no saved entry exists for the selected day
- include the dirty-state flag in the memo dependencies so the cycle day recomputes when the draft changes

## Testing
- npm run lint
- npm run build
- npm run export

------
https://chatgpt.com/codex/tasks/task_e_68f631ce21e4832a847c9821d034da3e