### PR TITLE
Preserve section confetti until animation completes

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -291,17 +291,28 @@ function Section({
   }, []);
 
   useEffect(() => {
-    if (timeoutRef.current !== null) {
-      window.clearTimeout(timeoutRef.current);
-      timeoutRef.current = null;
-    }
+    const cancelTimeout = () => {
+      if (timeoutRef.current !== null) {
+        window.clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+    };
+
     if (!completionEnabled) {
+      cancelTimeout();
       setIsCompleted(false);
       setShowConfetti(false);
       return;
     }
-    setShowConfetti(false);
-    setIsCompleted(completedFromContext);
+
+    if (!completedFromContext) {
+      cancelTimeout();
+      setIsCompleted(false);
+      setShowConfetti(false);
+      return;
+    }
+
+    setIsCompleted(true);
   }, [completedFromContext, completionEnabled]);
 
   const scrollToNextSection = () => {


### PR DESCRIPTION
## Summary
- adjust the section completion effect to only clear confetti timeouts when the section becomes incomplete or disabled
- keep local completion state synced with the context without interrupting the confetti animation

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68f775b86728832ab5595e8fffad61e3