### PR TITLE
Show birthday greeting only on November 10 2025

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -45,3 +45,40 @@ textarea:focus-visible {
   background-color: var(--section-card-completed-bg);
   border-color: var(--section-card-completed-border);
 }
+
+.heart-3d-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  perspective: 1200px;
+  width: 16rem;
+  height: 16rem;
+}
+
+.heart-3d {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  transform-style: preserve-3d;
+  animation: heart-spin 8s linear infinite;
+}
+
+.heart-3d svg {
+  filter: drop-shadow(0 20px 35px rgba(244, 114, 182, 0.35));
+}
+
+@keyframes heart-spin {
+  0% {
+    transform: rotateY(0deg) rotateX(8deg) scale(1);
+  }
+
+  50% {
+    transform: rotateY(180deg) rotateX(-8deg) scale(1.05);
+  }
+
+  100% {
+    transform: rotateY(360deg) rotateX(8deg) scale(1);
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { createContext, useCallback, useContext, useEffect, useId, useMemo, useRef, useState } from "react";
 import type { ChangeEvent, ReactNode } from "react";
 import {
   LineChart,
@@ -1091,6 +1091,17 @@ export default function HomePage() {
   const [featureFlags, setFeatureFlags, featureStorage] = usePersistentState<FeatureFlags>("endo.flags.v1", {});
   const [sectionCompletionState, setSectionCompletionState, sectionCompletionStorage] =
     usePersistentState<SectionCompletionState>("endo.sectionCompletion.v1", {});
+
+  const isBirthdayGreetingDay = () => {
+    const now = new Date();
+    return now.getFullYear() === 2025 && now.getMonth() === 10 && now.getDate() === 10;
+  };
+  const [showBirthdayGreeting, setShowBirthdayGreeting] = useState(isBirthdayGreetingDay);
+  const heartGradientReactId = useId();
+  const heartGradientId = useMemo(
+    () => `heart-gradient-${heartGradientReactId.replace(/:/g, "")}`,
+    [heartGradientReactId]
+  );
 
   const storageMetas = [dailyStorage, weeklyStorage, monthlyStorage, featureStorage, sectionCompletionStorage];
   const storageReady = storageMetas.every((meta) => meta.ready);
@@ -2661,8 +2672,46 @@ export default function HomePage() {
   const installHintVisible = showInstallHint && !isStandalone;
 
   return (
-    <SectionCompletionContext.Provider value={sectionCompletionContextValue}>
-      <main className="mx-auto flex max-w-6xl flex-col gap-8 px-4 py-8">
+    <>
+      {showBirthdayGreeting && (
+        <div
+          className="fixed inset-0 z-[100] flex flex-col bg-gradient-to-br from-rose-50 via-white to-rose-100 px-6 py-12 text-center"
+          role="dialog"
+          aria-modal="true"
+        >
+          <div className="flex flex-1 flex-col items-center justify-center gap-8">
+            <h1 className="text-4xl font-extrabold tracking-tight text-rose-700 sm:text-5xl">
+              Alles Liebe zum Geburtstag!
+            </h1>
+            <div className="heart-3d-container">
+              <div className="heart-3d">
+                <svg viewBox="0 0 512 512" className="h-full w-full" aria-hidden="true" focusable="false">
+                  <defs>
+                    <linearGradient id={heartGradientId} x1="0%" y1="0%" x2="100%" y2="100%">
+                      <stop offset="0%" stopColor="#f9a8d4" />
+                      <stop offset="50%" stopColor="#f472b6" />
+                      <stop offset="100%" stopColor="#db2777" />
+                    </linearGradient>
+                  </defs>
+                  <path
+                    d="M256 464l-35.35-32.33C118.6 343.5 48 279.4 48 196.6 48 131 99 80 164.5 80c37.5 0 73.5 17.7 96 45.2C283.9 97.7 319.9 80 357.4 80 423 80 474 131 474 196.6c0 82.8-70.6 146.9-172.7 235.1L256 464z"
+                    fill={`url(#${heartGradientId})`}
+                  />
+                </svg>
+              </div>
+            </div>
+          </div>
+          <Button
+            type="button"
+            onClick={() => setShowBirthdayGreeting(false)}
+            className="mx-auto mt-auto w-full max-w-xs rounded-full bg-rose-600 py-4 text-lg font-semibold shadow-lg transition hover:bg-rose-500"
+          >
+            weiter zur App
+          </Button>
+        </div>
+      )}
+      <SectionCompletionContext.Provider value={sectionCompletionContextValue}>
+        <main className="mx-auto flex max-w-6xl flex-col gap-8 px-4 py-8">
         <header className="flex flex-col gap-2">
           <h1 className="text-2xl font-semibold text-rose-900">Endometriose Symptomtracker</h1>
           <p className="text-sm text-rose-700">
@@ -4888,5 +4937,6 @@ export default function HomePage() {
       </Tabs>
       </main>
     </SectionCompletionContext.Provider>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- remove the unsupported `size="lg"` prop from the birthday greeting CTA
- rely on custom padding classes to retain the intended visual appearance
- show the birthday greeting overlay exclusively on 10.11.2025

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68f790bd5468832a9f5f3cce6417a170