### PR TITLE
Add weekly reporting tests and vitest configuration

### DIFF
--- a/app/weekly/components/WeeklyPrompts.test.tsx
+++ b/app/weekly/components/WeeklyPrompts.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { PromptAnswers } from "@/lib/weekly/drafts";
+import type { SuggestionSection } from "@/lib/weekly/suggestions";
+
+import { WeeklyPrompts } from "./WeeklyPrompts";
+
+const suggestionStore: Record<SuggestionSection, string[]> = {
+  helped: [],
+  worsened: [],
+  nextWeekTry: [],
+};
+
+const getSuggestedChipsMock = vi.fn(async (section: SuggestionSection) => {
+  return [...suggestionStore[section]];
+});
+
+const rememberChosenChipsMock = vi.fn(async (section: SuggestionSection, items: string[]) => {
+  const normalized = items.map((item) => item.trim()).filter(Boolean);
+  const merged = [...normalized, ...suggestionStore[section]];
+  const deduped = Array.from(new Map(merged.map((item) => [item.toLocaleLowerCase(), item])).values());
+  suggestionStore[section] = deduped;
+});
+
+vi.mock("@/lib/weekly/suggestions", () => ({
+  getSuggestedChips: getSuggestedChipsMock,
+  rememberChosenChips: rememberChosenChipsMock,
+}));
+
+describe("WeeklyPrompts", () => {
+  beforeEach(() => {
+    suggestionStore.helped = [];
+    suggestionStore.worsened = [];
+    suggestionStore.nextWeekTry = [];
+    getSuggestedChipsMock.mockClear();
+    rememberChosenChipsMock.mockClear();
+  });
+
+  it("persists selected chips and suggests them again on the next render", async () => {
+    const user = userEvent.setup();
+    const initialAnswers: PromptAnswers = { helped: [], worsened: [], nextWeekTry: [], freeText: "" };
+    const handleChange = vi.fn();
+
+    const { unmount } = render(<WeeklyPrompts value={initialAnswers} onChange={handleChange} />);
+
+    expect(await screen.findByText("Noch keine Vorschläge vorhanden.")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Akupunktur" })).not.toBeInTheDocument();
+
+    await user.type(screen.getByLabelText("Eigenen Punkt hinzufügen"), "Akupunktur");
+    await user.click(screen.getAllByRole("button", { name: "Als Chip übernehmen" })[0]);
+
+    await waitFor(() => {
+      expect(handleChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({ helped: ["Akupunktur"] })
+      );
+    });
+    expect(await screen.findByRole("button", { name: "Akupunktur" })).toBeInTheDocument();
+    expect(rememberChosenChipsMock).toHaveBeenCalledWith("helped", ["Akupunktur"]);
+
+    unmount();
+
+    const nextHandleChange = vi.fn();
+    render(<WeeklyPrompts value={initialAnswers} onChange={nextHandleChange} />);
+
+    await waitFor(() => {
+      expect(screen.queryByText("Noch keine Vorschläge vorhanden.")).not.toBeInTheDocument();
+    });
+    const restoredChip = await screen.findByRole("button", { name: "Akupunktur" });
+    expect(restoredChip).toBeInTheDocument();
+    expect(nextHandleChange).not.toHaveBeenCalled();
+  });
+});

--- a/lib/weekly/aggregate.test.ts
+++ b/lib/weekly/aggregate.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+
+import { computeWeeklyStats, detectHighlights, type WeeklyStats } from "./aggregate";
+
+describe("computeWeeklyStats", () => {
+  const weekStart = "2024-05-13";
+  const weekEnd = "2024-05-19";
+
+  it("returns neutral stats when no entries are available", () => {
+    const stats = computeWeeklyStats([], weekStart, weekEnd);
+
+    expect(stats.avgPain).toBeNull();
+    expect(stats.maxPain).toBeNull();
+    expect(stats.badDaysCount).toBe(0);
+    expect(stats.bleedingDaysCount).toBe(0);
+    expect(stats.notes).toEqual({ medicationChange: false, sleepBelowUsual: false });
+    expect(stats.sparkline).toHaveLength(7);
+    expect(stats.sparkline.every((point) => point.pain === null)).toBe(true);
+  });
+
+  it("handles a single day with measurements correctly", () => {
+    const daily = [
+      { dateISO: "2024-05-10", sleepQuality0to10: 6 },
+      { dateISO: "2024-05-11", sleepQuality0to10: 7 },
+      { dateISO: "2024-05-12", sleepQuality0to10: 6 },
+      {
+        dateISO: "2024-05-14",
+        pain0to10: 5,
+        bleeding: "light" as const,
+        medicationsChanged: true,
+        sleepQuality0to10: 6,
+      },
+      { dateISO: "2024-05-20", pain0to10: 8 },
+    ];
+
+    const stats = computeWeeklyStats(daily, weekStart, weekEnd);
+
+    expect(stats.avgPain).toBe(5);
+    expect(stats.maxPain).toBe(5);
+    expect(stats.badDaysCount).toBe(0);
+    expect(stats.bleedingDaysCount).toBe(1);
+    expect(stats.notes).toEqual({ medicationChange: true, sleepBelowUsual: false });
+    expect(stats.sparkline.find((point) => point.dateISO === "2024-05-14")?.pain).toBe(5);
+  });
+
+  it("captures outlier pain values without losing overall accuracy", () => {
+    const daily = [
+      { dateISO: "2024-05-13", pain0to10: 2 },
+      { dateISO: "2024-05-14", pain0to10: 10 },
+      { dateISO: "2024-05-15", pain0to10: 3 },
+      { dateISO: "2024-05-16", pain0to10: 2 },
+    ];
+
+    const stats = computeWeeklyStats(daily, weekStart, weekEnd);
+
+    expect(stats.avgPain).toBe(4.25);
+    expect(stats.maxPain).toBe(10);
+    expect(stats.badDaysCount).toBe(1);
+    expect(stats.sparkline.find((point) => point.dateISO === "2024-05-14")?.pain).toBe(10);
+  });
+
+  it("supports weeks with missing pain data and still detects sleep trends", () => {
+    const daily = [
+      { dateISO: "2024-05-13", sleepQuality0to10: 4 },
+      { dateISO: "2024-05-14", sleepQuality0to10: 4 },
+      { dateISO: "2024-05-15", sleepQuality0to10: 4 },
+      { dateISO: "2024-05-16", sleepQuality0to10: 4 },
+      { dateISO: "2024-05-17", sleepQuality0to10: 4 },
+      { dateISO: "2024-05-10", sleepQuality0to10: 7 },
+      { dateISO: "2024-05-11", sleepQuality0to10: 7 },
+      { dateISO: "2024-05-12", sleepQuality0to10: 7 },
+    ];
+
+    const stats = computeWeeklyStats(daily, weekStart, weekEnd);
+
+    expect(stats.avgPain).toBeNull();
+    expect(stats.maxPain).toBeNull();
+    expect(stats.badDaysCount).toBe(0);
+    expect(stats.bleedingDaysCount).toBe(0);
+    expect(stats.sparkline.every((point) => point.pain === null)).toBe(true);
+    expect(stats.notes).toEqual({ medicationChange: false, sleepBelowUsual: true });
+  });
+});
+
+describe("detectHighlights", () => {
+  const baseStats: WeeklyStats = {
+    isoWeekKey: "2024-W20",
+    startISO: "2024-05-13",
+    endISO: "2024-05-19",
+    avgPain: 6.5,
+    maxPain: 8,
+    badDaysCount: 3,
+    bleedingDaysCount: 2,
+    sparkline: [],
+    notes: { medicationChange: true, sleepBelowUsual: true },
+  };
+
+  it("collects highlights when medication changes, poor sleep and pain spikes occur", () => {
+    const history: WeeklyStats[] = [
+      {
+        ...baseStats,
+        avgPain: 4,
+        notes: { medicationChange: false, sleepBelowUsual: false },
+      },
+      {
+        ...baseStats,
+        avgPain: 5,
+        notes: { medicationChange: false, sleepBelowUsual: false },
+      },
+    ];
+
+    const highlights = detectHighlights(baseStats, history);
+
+    expect(highlights).toEqual([
+      { kind: "medication_change", message: "Medication changes documented this week." },
+      { kind: "poor_sleep", message: "Sleep quality trended below usual levels." },
+      {
+        kind: "above_trend",
+        message: "Average pain (6.5) exceeded the recent baseline (4.5).",
+      },
+    ]);
+  });
+
+  it("does not add trend highlights when averages are missing", () => {
+    const stats: WeeklyStats = {
+      ...baseStats,
+      avgPain: null,
+      notes: { medicationChange: false, sleepBelowUsual: false },
+    };
+
+    const history: WeeklyStats[] = [
+      {
+        ...baseStats,
+        avgPain: 4,
+        notes: { medicationChange: false, sleepBelowUsual: false },
+      },
+    ];
+
+    const highlights = detectHighlights(stats, history);
+
+    expect(highlights).toEqual([]);
+  });
+});

--- a/lib/weekly/flow.e2e.test.ts
+++ b/lib/weekly/flow.e2e.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { clearAll } from "@/lib/persistence";
+import { exportWeeklyReportPDF } from "@/lib/export/pdfWeekly";
+import { computeWeeklyStats } from "@/lib/weekly/aggregate";
+import { saveWeeklyDraft, loadWeeklyDraft } from "@/lib/weekly/drafts";
+import { listWeeklyReports, storeWeeklyReport } from "@/lib/weekly/reports";
+
+const isoWeekKey = "2024-W20";
+const weekStartISO = "2024-05-13";
+const weekEndISO = "2024-05-19";
+
+describe("weekly reporting flow", () => {
+  beforeEach(async () => {
+    await clearAll();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("creates a draft, resumes it, submits a report and exports a PDF", async () => {
+    vi.useFakeTimers();
+
+    const answers = {
+      helped: ["Wärmeflasche"],
+      worsened: ["Stress"],
+      nextWeekTry: ["Yoga"],
+      freeText: "Ruhige Woche",
+    };
+
+    const draft = {
+      isoWeekKey,
+      confirmedSummary: false,
+      answers,
+      progress: 2 as const,
+      updatedAt: Date.now(),
+    };
+
+    const savePromise = saveWeeklyDraft(draft);
+    await vi.runAllTimersAsync();
+    await savePromise;
+
+    const resumedDraft = await loadWeeklyDraft(isoWeekKey);
+    expect(resumedDraft).toEqual(expect.objectContaining({ isoWeekKey, answers }));
+
+    const dailyEntries = [
+      { dateISO: "2024-05-10", sleepQuality0to10: 7 },
+      { dateISO: "2024-05-11", sleepQuality0to10: 7 },
+      { dateISO: "2024-05-12", sleepQuality0to10: 7 },
+      { dateISO: "2024-05-13", pain0to10: 4, sleepQuality0to10: 5 },
+      { dateISO: "2024-05-14", pain0to10: 6, bleeding: "light" as const, medicationsChanged: true, sleepQuality0to10: 5 },
+      { dateISO: "2024-05-15", pain0to10: 5, sleepQuality0to10: 4 },
+      { dateISO: "2024-05-16", pain0to10: 3, sleepQuality0to10: 4 },
+      { dateISO: "2024-05-17", pain0to10: 4, sleepQuality0to10: 4 },
+    ];
+
+    const stats = computeWeeklyStats(dailyEntries, weekStartISO, weekEndISO);
+    expect(stats.avgPain).toBeGreaterThan(0);
+
+    const submittedAt = Date.now();
+    await storeWeeklyReport({ isoWeekKey, stats, answers, submittedAt });
+
+    const reports = await listWeeklyReports();
+    expect(reports).toHaveLength(1);
+    const storedReport = reports[0];
+    expect(storedReport.isoWeekKey).toBe(isoWeekKey);
+    expect(storedReport.answers.helped).toContain("Wärmeflasche");
+    expect(storedReport.stats.avgPain).toBe(stats.avgPain);
+
+    const createObjectURL = vi.fn(() => "blob:weekly-report");
+    const revokeObjectURL = vi.fn();
+    Object.defineProperty(window.URL, "createObjectURL", {
+      value: createObjectURL,
+      writable: true,
+    });
+    Object.defineProperty(window.URL, "revokeObjectURL", {
+      value: revokeObjectURL,
+      writable: true,
+    });
+
+    const pdfBlob = await exportWeeklyReportPDF(storedReport);
+    expect(pdfBlob).toBeInstanceOf(Blob);
+    expect(createObjectURL).toHaveBeenCalledWith(pdfBlob);
+    expect(revokeObjectURL).not.toHaveBeenCalled();
+    expect(document.body.querySelector("a")).not.toBeInTheDocument();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "export": "next build && next export"
+    "export": "next build && next export",
+    "test": "vitest"
   },
   "dependencies": {
     "lucide-react": "^0.363.0",
@@ -26,6 +27,10 @@
     "autoprefixer": "^10.4.16",
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^14.3.1",
+    "@testing-library/user-event": "^14.5.1",
+    "vitest": "^1.5.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,9 @@
     "jsx": "preserve",
     "incremental": true,
     "types": [
-      "node"
+      "node",
+      "vitest/globals",
+      "@testing-library/jest-dom"
     ],
     "plugins": [
       {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "."),
+    },
+  },
+  test: {
+    globals: true,
+    environment: "jsdom",
+    setupFiles: ["./vitest.setup.ts"],
+    include: ["**/*.test.{ts,tsx}", "**/*.e2e.test.{ts,tsx}"],
+  },
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";


### PR DESCRIPTION
## Summary
- add a Vitest configuration and testing dependencies for the weekly features
- cover computeWeeklyStats and detectHighlights with comprehensive edge-case unit tests
- ensure WeeklyPrompts persists chip selections and add an end-to-end weekly reporting flow test

## Testing
- `npm test -- --run` *(fails: Vitest binary not installed because npm registry access for @testing-library/jest-dom was forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f8f005d664832ab2f70a9cf0cafbd8