### PR TITLE
Improve weekly overview guidance and sparkline performance

### DIFF
--- a/app/weekly/WeeklyForm.tsx
+++ b/app/weekly/WeeklyForm.tsx
@@ -353,6 +353,9 @@ export default function WeeklyForm(props: { year: number; week: number }): JSX.E
   if (activeStep === 1) {
     stepContent = (
       <div className="space-y-6">
+        <p className="text-sm text-rose-900/70">
+          Bitte bestätige die automatisch erstellte Wochenübersicht. Du kannst Werte jederzeit korrigieren.
+        </p>
         {weeklyStats ? (
           <WeeklySummaryCard
             stats={weeklyStats}
@@ -469,6 +472,10 @@ export default function WeeklyForm(props: { year: number; week: number }): JSX.E
           </p>
         </header>
 
+        <p className="text-sm text-rose-900/70">
+          Bitte bestätige die automatisch erstellte Wochenübersicht. Du kannst Werte jederzeit korrigieren.
+        </p>
+
         {weeklyStats ? (
           <WeeklySummaryCard
             stats={weeklyStats}
@@ -521,7 +528,7 @@ export default function WeeklyForm(props: { year: number; week: number }): JSX.E
 
         {!weeklyDraft.confirmedSummary ? (
           <p className="text-sm text-rose-900">
-            Bitte bestätige die Zusammenfassung im ersten Schritt, bevor du absendest.
+            Bitte bestätige die automatisch erstellte Wochenübersicht im ersten Schritt, bevor du absendest.
           </p>
         ) : null}
         {submitError ? (

--- a/app/weekly/components/WeeklyPrompts.tsx
+++ b/app/weekly/components/WeeklyPrompts.tsx
@@ -135,7 +135,7 @@ export function WeeklyPrompts({ value, onChange }: { value: PromptAnswers; onCha
       <header className="space-y-1">
         <h2 className="text-xl font-semibold text-rose-900">Wöchentliche Leitfragen</h2>
         <p className="text-sm text-rose-900/70">
-          Wähle passende Punkte aus oder ergänze eigene Notizen. Deine Auswahl bleibt nur lokal gespeichert.
+          Wähle passende Chips oder ergänze eigene Stichworte. Deine Auswahl wird lokal gemerkt.
         </p>
       </header>
 

--- a/app/weekly/components/WeeklySummaryCard.tsx
+++ b/app/weekly/components/WeeklySummaryCard.tsx
@@ -12,13 +12,15 @@ import {
   CartesianGrid,
 } from "recharts";
 import type { TooltipProps } from "recharts";
-import { useMemo, useCallback } from "react";
+import { useMemo, useCallback, useRef, memo } from "react";
 
 type WeeklySummaryCardProps = {
   stats: WeeklyStats;
   confirmed: boolean;
   onConfirmChange: (value: boolean) => void;
 };
+
+const MAX_SPARKLINE_POINTS = 7;
 
 type SparklinePoint = {
   dateISO: string;
@@ -38,21 +40,7 @@ function formatPain(value: number | null): string {
 const TICKS = [0, 2, 4, 6, 8, 10];
 
 export function WeeklySummaryCard({ stats, confirmed, onConfirmChange }: WeeklySummaryCardProps): JSX.Element {
-  const sparklineData = useMemo<SparklinePoint[]>(() => {
-    return stats.sparkline.map((point) => {
-      const date = new Date(`${point.dateISO}T00:00:00Z`);
-      const label = date.toLocaleDateString("de-DE", { weekday: "short" });
-      const missing = point.pain === null || Number.isNaN(point.pain ?? NaN);
-      const pain = missing ? undefined : point.pain ?? undefined;
-      return {
-        dateISO: point.dateISO,
-        label,
-        pain,
-        missing,
-        displayValue: formatPain(point.pain),
-      };
-    });
-  }, [stats.sparkline]);
+  const sparklineData = useStableSparklineData(stats.sparkline);
 
   const tooltipFormatter = useCallback<
     NonNullable<TooltipProps<string | number, string>["formatter"]>
@@ -105,48 +93,7 @@ export function WeeklySummaryCard({ stats, confirmed, onConfirmChange }: WeeklyS
           <SummaryTile label="Blutungstage" value={bleedingDays.toString()} />
         </div>
         <div className="h-40 w-full">
-          <ResponsiveContainer>
-            <LineChart data={sparklineData} margin={{ top: 10, right: 16, bottom: 4, left: 0 }}>
-              <CartesianGrid stroke="rgba(244, 219, 227, 0.8)" strokeDasharray="4 4" vertical={false} />
-              <XAxis
-                dataKey="label"
-                tick={{ fill: "#9f1239", fontSize: 12 }}
-                axisLine={{ stroke: "#fda4af" }}
-                tickLine={false}
-              />
-              <YAxis
-                ticks={TICKS}
-                domain={[0, 10]}
-                allowDecimals={false}
-                width={36}
-                tick={{ fill: "#9f1239", fontSize: 12 }}
-                axisLine={{ stroke: "#fda4af" }}
-                tickLine={false}
-              />
-              <Tooltip
-                formatter={tooltipFormatter}
-                labelFormatter={(_label, payload) => {
-                  const point = payload?.[0]?.payload as SparklinePoint | undefined;
-                  return point?.dateISO ?? "";
-                }}
-                contentStyle={{
-                  borderRadius: 12,
-                  borderColor: "#fb7185",
-                  backgroundColor: "white",
-                  color: "#881337",
-                }}
-              />
-              <Line
-                type="monotone"
-                dataKey="pain"
-                stroke="#f43f5e"
-                strokeWidth={2}
-                dot={{ r: 3, stroke: "#f43f5e", strokeWidth: 1, fill: "white" }}
-                activeDot={{ r: 5, stroke: "#f43f5e", strokeWidth: 2, fill: "white" }}
-                connectNulls
-              />
-            </LineChart>
-          </ResponsiveContainer>
+          <SparklineChart data={sparklineData} tooltipFormatter={tooltipFormatter} />
         </div>
       </CardContent>
     </Card>
@@ -166,3 +113,107 @@ function SummaryTile({ label, value }: SummaryTileProps): JSX.Element {
     </div>
   );
 }
+
+function useStableSparklineData(points: WeeklyStats["sparkline"]): SparklinePoint[] {
+  const formatted = useMemo<SparklinePoint[]>(() => {
+    return points.slice(0, MAX_SPARKLINE_POINTS).map((point) => {
+      const date = new Date(`${point.dateISO}T00:00:00Z`);
+      const label = date.toLocaleDateString("de-DE", { weekday: "short" });
+      const missing = point.pain === null || Number.isNaN(point.pain ?? NaN);
+      const pain = missing ? undefined : point.pain ?? undefined;
+      return {
+        dateISO: point.dateISO,
+        label,
+        pain,
+        missing,
+        displayValue: formatPain(point.pain),
+      };
+    });
+  }, [points]);
+
+  const stableRef = useRef<SparklinePoint[] | null>(null);
+
+  return useMemo(() => {
+    if (!stableRef.current || !areSparklinePointsEqual(stableRef.current, formatted)) {
+      stableRef.current = formatted;
+    }
+    return stableRef.current;
+  }, [formatted]);
+}
+
+function areSparklinePointsEqual(a: SparklinePoint[], b: SparklinePoint[]): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+
+  for (let index = 0; index < a.length; index += 1) {
+    const current = a[index];
+    const next = b[index];
+    if (
+      current.dateISO !== next.dateISO ||
+      current.label !== next.label ||
+      current.pain !== next.pain ||
+      current.missing !== next.missing ||
+      current.displayValue !== next.displayValue
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+type SparklineChartProps = {
+  data: SparklinePoint[];
+  tooltipFormatter: NonNullable<TooltipProps<string | number, string>["formatter"]>;
+};
+
+const SparklineChart = memo(
+  function SparklineChart({ data, tooltipFormatter }: SparklineChartProps): JSX.Element {
+    return (
+      <ResponsiveContainer>
+        <LineChart data={data} margin={{ top: 10, right: 16, bottom: 4, left: 0 }}>
+          <CartesianGrid stroke="rgba(244, 219, 227, 0.8)" strokeDasharray="4 4" vertical={false} />
+          <XAxis
+            dataKey="label"
+            tick={{ fill: "#9f1239", fontSize: 12 }}
+            axisLine={{ stroke: "#fda4af" }}
+            tickLine={false}
+          />
+          <YAxis
+            ticks={TICKS}
+            domain={[0, 10]}
+            allowDecimals={false}
+            width={36}
+            tick={{ fill: "#9f1239", fontSize: 12 }}
+            axisLine={{ stroke: "#fda4af" }}
+            tickLine={false}
+          />
+          <Tooltip
+            formatter={tooltipFormatter}
+            labelFormatter={(_label, payload) => {
+              const point = payload?.[0]?.payload as SparklinePoint | undefined;
+              return point?.dateISO ?? "";
+            }}
+            contentStyle={{
+              borderRadius: 12,
+              borderColor: "#fb7185",
+              backgroundColor: "white",
+              color: "#881337",
+            }}
+          />
+          <Line
+            type="monotone"
+            dataKey="pain"
+            stroke="#f43f5e"
+            strokeWidth={2}
+            dot={{ r: 3, stroke: "#f43f5e", strokeWidth: 1, fill: "white" }}
+            activeDot={{ r: 5, stroke: "#f43f5e", strokeWidth: 2, fill: "white" }}
+            connectNulls
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    );
+  },
+  (prev, next) => prev.data === next.data && prev.tooltipFormatter === next.tooltipFormatter
+);

--- a/app/weekly/danke/page.tsx
+++ b/app/weekly/danke/page.tsx
@@ -185,7 +185,7 @@ function WeeklyThankYouContent(): JSX.Element {
           <p className="text-sm font-medium uppercase tracking-wide text-rose-500">Danke</p>
           <h1 className="text-3xl font-semibold text-rose-900">Wochenbericht gespeichert</h1>
           <p className="text-sm text-rose-900/70">
-            Dein Bericht für {weekLabel} wurde gesichert. Wähle eine der folgenden Aktionen, um nahtlos weiterzumachen.
+            Danke. Möchtest du die Woche als A4 speichern oder eine Erinnerung für nächsten Sonntag erhalten?
           </p>
         </header>
 


### PR DESCRIPTION
## Summary
- update weekly overview copy to guide confirmation, prompts, and follow-up actions
- stabilize the weekly sparkline data so Recharts only renders when values change and limit the chart to seven points

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f8f3ddd2e4832a9161285ea0573228