### PR TITLE
Improve responsiveness on small screens

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -9,11 +9,19 @@
   --section-card-completed-border: #facc15;
 }
 
+html {
+  width: 100%;
+  overflow-x: hidden;
+}
+
 body {
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   background-color: var(--endo-bg);
   color: #111827;
   transition: background-color 0.3s ease;
+  width: 100%;
+  max-width: 100%;
+  overflow-x: hidden;
 }
 
 button:focus-visible,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1007,7 +1007,7 @@ function normalizeImportedMonthlyEntry(entry: MonthlyEntry & Record<string, unkn
 
 function BodyMap({ value, onChange }: { value: string[]; onChange: (next: string[]) => void }) {
   return (
-    <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+    <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 md:grid-cols-3">
       {BODY_REGIONS.map((region) => (
         <button
           key={region.id}
@@ -4440,7 +4440,7 @@ export default function HomePage() {
                   description="Durchschnittlicher NRS nach Wochentag"
                   completionEnabled={false}
                 >
-                  <div className="grid grid-cols-2 gap-2 text-xs text-rose-700 sm:grid-cols-4">
+                  <div className="grid grid-cols-1 gap-2 text-xs text-rose-700 sm:grid-cols-2 lg:grid-cols-4">
                     {weekdayOverlay.map((row) => (
                       <div key={row.weekday} className="rounded border border-amber-100 bg-amber-50 px-2 py-1">
                         <p className="font-semibold text-rose-800">{row.weekday}</p>


### PR DESCRIPTION
## Summary
- prevent horizontal overflow by constraining the html and body elements to the viewport width
- adjust body map and weekday overlay grids to stack comfortably on very small screens

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fa5f09f1fc832a8836d06132b6bc89