### PR TITLE
Consolidate bowel and urinary pain scores

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -30,8 +30,8 @@ export interface DailyEntry {
   rescueDosesCount?: number;
 
   sleep?: { hours?: number; quality?: number; awakenings?: number };
-  gi?: { bristolType?: 1 | 2 | 3 | 4 | 5 | 6 | 7; bowelPain?: number };
-  urinary?: { freqPerDay?: number; urgency?: number; pain?: number };
+  gi?: { bristolType?: 1 | 2 | 3 | 4 | 5 | 6 | 7 };
+  urinary?: { freqPerDay?: number; urgency?: number };
 
   activity?: { steps?: number; activeMinutes?: number }; // optional, Hilfsmittel
   exploratory?: { hrvRmssdMs?: number }; // optional, Hilfsmittel

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -217,13 +217,10 @@ export function validateDailyEntry(entry: DailyEntry): ValidationIssue[] {
     if (entry.gi.bristolType !== undefined && ![1, 2, 3, 4, 5, 6, 7].includes(entry.gi.bristolType)) {
       issues.push({ path: "gi.bristolType", message: "Bristol-Score muss zwischen 1 und 7 liegen." });
     }
-    if (entry.gi.bowelPain !== undefined && !intRange(entry.gi.bowelPain, 0, 10)) {
-      issues.push({ path: "gi.bowelPain", message: "Darm-Schmerz muss 0–10 (Ganzzahl) sein." });
-    }
   }
 
   if (entry.urinary) {
-    const { freqPerDay, urgency, pain } = entry.urinary;
+    const { freqPerDay, urgency } = entry.urinary;
     if (freqPerDay !== undefined && (!Number.isInteger(freqPerDay) || freqPerDay < 0)) {
       issues.push({
         path: "urinary.freqPerDay",
@@ -232,9 +229,6 @@ export function validateDailyEntry(entry: DailyEntry): ValidationIssue[] {
     }
     if (urgency !== undefined && !intRange(urgency, 0, 10)) {
       issues.push({ path: "urinary.urgency", message: "Drang muss 0–10 (Ganzzahl) sein." });
-    }
-    if (pain !== undefined && !intRange(pain, 0, 10)) {
-      issues.push({ path: "urinary.pain", message: "Blasenschmerz muss 0–10 (Ganzzahl) sein." });
     }
   }
 


### PR DESCRIPTION
## Summary
- keep bowel and bladder pain sliders in the daily flow but bind them to the dyschezia and dysuria symptom scores instead of standalone fields
- add migration logic for existing entries so legacy gi.bowelPain and urinary.pain values feed the symptom records and stop persisting the redundant keys
- simplify types/validation to reflect the single source of truth and surface symptom scores in exports and summaries

## Testing
- npm test *(fails: prompts to install missing dependency `jsdom`)*

------
https://chatgpt.com/codex/tasks/task_e_68fa676d6684832a9fee9d0c57c6835e