### PR TITLE
Replace weekly reminder badge text with indicator

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3034,7 +3034,7 @@ export default function HomePage() {
             Wöchentlich
             {showWeeklyReminderBadge ? (
               <Badge className="bg-amber-400 text-rose-900" aria-label="Wöchentlicher Check-in fällig">
-                fällig
+                <span className="inline-block h-2 w-2 rounded-full bg-rose-600" aria-hidden="true" />
               </Badge>
             ) : null}
           </TabsTrigger>


### PR DESCRIPTION
## Summary
- replace the "fällig" text in the weekly reminder badge with a red dot indicator while keeping the existing aria label

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fdf7ef3afc832ab859a9860bf5b6b5