### PR TITLE
Add sticky toolbar with progress summary to detail views

### DIFF
--- a/components/weekly/WeeklyTabShell.tsx
+++ b/components/weekly/WeeklyTabShell.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import WeeklyForm, { WeeklyProvider } from "@/app/weekly/WeeklyForm";
 import type { DailyEntry } from "@/lib/types";
@@ -49,9 +49,10 @@ function formatWeekRangeLabel(year: number, week: number): string {
 type WeeklyTabShellProps = {
   dailyEntries: DailyEntry[];
   currentIsoWeek: string;
+  onSelectionChange?: (isoWeek: string) => void;
 };
 
-export function WeeklyTabShell({ dailyEntries, currentIsoWeek }: WeeklyTabShellProps): JSX.Element {
+export function WeeklyTabShell({ dailyEntries, currentIsoWeek, onSelectionChange }: WeeklyTabShellProps): JSX.Element {
   const currentParts = useMemo(() => parseIsoWeek(currentIsoWeek) ?? getIsoWeekParts(new Date()), [currentIsoWeek]);
   const [selected, setSelected] = useState(currentParts);
 
@@ -95,6 +96,10 @@ export function WeeklyTabShell({ dailyEntries, currentIsoWeek }: WeeklyTabShellP
       dailyEntries.filter((entry) => getIsoWeekStringFromDateString(entry.date) === selectedIsoWeek),
     [dailyEntries, selectedIsoWeek]
   );
+
+  useEffect(() => {
+    onSelectionChange?.(selectedIsoWeek);
+  }, [onSelectionChange, selectedIsoWeek]);
 
   return (
     <WeeklyProvider year={selected.year} week={selected.week} dailyEntries={entriesForWeek}>


### PR DESCRIPTION
## Summary
- add a sticky toolbar for the daily, weekly, and monthly views that shows the back navigation, the selected period, and the completed-section counter
- track section registration to compute per-scope completion totals for the progress indicator
- surface the weekly tab's selected ISO week to the parent so the toolbar stays in sync

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_690620c57ba8832a8cc36e816b2b6235