### PR TITLE
Make detail toolbar sticky

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3040,9 +3040,12 @@ export default function HomePage() {
   const currentDataView = isHomeView ? "daily" : activeView;
 
   const detailToolbar = !isHomeView ? (
-    <header
-      className="sticky top-0 z-30 w-full border-b border-rose-100 bg-white/90 shadow-sm backdrop-blur supports-[backdrop-filter:none]:bg-white"
-      style={{ backgroundColor: "var(--endo-bg, #fff)" }}
+    <div
+      className="sticky top-0 z-40 w-full border-b border-rose-100 bg-white/90 shadow-sm backdrop-blur supports-[backdrop-filter:none]:bg-white"
+      style={{
+        backgroundColor: "var(--endo-bg, #fff)",
+        top: "env(safe-area-inset-top, 0px)",
+      }}
     >
       <div className="mx-auto flex max-w-6xl flex-col gap-2 px-4 pt-[calc(env(safe-area-inset-top,0px)+1rem)] pb-3">
         <div className="flex flex-wrap items-center justify-between gap-3">
@@ -3063,7 +3066,7 @@ export default function HomePage() {
         </div>
         {infoMessage ? <p className="text-xs text-rose-600 sm:text-sm">{infoMessage}</p> : null}
       </div>
-    </header>
+    </div>
   ) : null;
 
   return (


### PR DESCRIPTION
## Summary
- make the detail toolbar with the back button and info text sticky and raise its stacking context
- offset the sticky toolbar for safe-area insets while keeping the themed background

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690691149c44832a8a203f6e1d113ce5