### PR TITLE
Simplify cycle overview chart styling

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -312,6 +312,7 @@ type CycleOverviewChartPoint = CycleOverviewPoint & {
   bleedingLabel: string;
   bleedingValue: number;
   cycleDayLabel: string;
+  cycleDayValue: number | null;
   dateLabel: string;
   painValue: number;
 };
@@ -347,6 +348,7 @@ const CycleOverviewMiniChart = ({ data }: { data: CycleOverviewData }) => {
         bleedingLabel: bleeding.label,
         bleedingValue: bleeding.value,
         cycleDayLabel: point.cycleDay ? `ZT ${point.cycleDay}` : "ZT –",
+        cycleDayValue: point.cycleDay ?? null,
         dateLabel: formatShortGermanDate(point.date),
         painValue,
       };
@@ -380,33 +382,8 @@ const CycleOverviewMiniChart = ({ data }: { data: CycleOverviewData }) => {
   }
 
   return (
-    <section
-      className="rounded-2xl border border-rose-200 bg-white/70 p-4 shadow-sm backdrop-blur"
-      role="group"
-      aria-labelledby="cycle-overview-heading"
-    >
-      <div className="flex flex-wrap items-baseline justify-between gap-3">
-        <div>
-          <p id="cycle-overview-heading" className="text-xs font-semibold uppercase tracking-wide text-rose-500">
-            Aktueller Zyklus
-          </p>
-          <p className="text-lg font-semibold text-rose-900">
-            Start {formatShortGermanDate(data.startDate)}
-          </p>
-        </div>
-        <div className="flex flex-wrap items-center gap-3 text-[11px] text-rose-600">
-          <span className="flex items-center gap-1">
-            <span className="block h-2.5 w-2.5 rounded-full bg-rose-700" aria-hidden /> Schmerz
-          </span>
-          <span className="flex items-center gap-1">
-            <span className="block h-2 w-4 rounded bg-gradient-to-b from-rose-200 to-rose-400" aria-hidden /> Blutung
-          </span>
-          <span className="flex items-center gap-1">
-            <span className="block h-2.5 w-2.5 rounded-full border border-amber-400 bg-amber-200" aria-hidden /> Eisprung
-          </span>
-        </div>
-      </div>
-      <div className="mt-4 h-56 w-full sm:h-64">
+    <section aria-label="Aktueller Zyklus">
+      <div className="h-36 w-full sm:h-44">
         <ResponsiveContainer>
           <ComposedChart data={chartPoints} margin={{ top: 8, right: 16, bottom: 0, left: 0 }}>
             <defs>
@@ -416,10 +393,13 @@ const CycleOverviewMiniChart = ({ data }: { data: CycleOverviewData }) => {
               </linearGradient>
             </defs>
             <XAxis
-              dataKey="cycleDayLabel"
+              dataKey="cycleDayValue"
               axisLine={false}
               tickLine={false}
               tick={{ fill: "#fb7185", fontSize: 11 }}
+              tickFormatter={(value: number | null) =>
+                typeof value === "number" && Number.isFinite(value) ? `${value}` : ""
+              }
               minTickGap={6}
             />
             <YAxis domain={[0, 10]} hide />


### PR DESCRIPTION
## Summary
- remove card tile styling and header from the home cycle overview chart
- limit the x-axis labels to cycle day numbers only
- reduce the chart height so the visualization takes up less space

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_690720a4d1e0832a8ed6e8a9cfe8ec84