### PR TITLE
Extend DailyEntry pain fields

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -8,6 +8,15 @@ export interface FeatureFlags {
 
 export interface DailyEntry {
   date: string; // ISO YYYY-MM-DD
+
+  // Neu:
+  painRegions?: Array<{
+    regionId: ID;
+    nrs: number;
+    qualities: DailyEntry["painQuality"];
+  }>;
+
+  impactNRS?: number;
   painNRS: number; // 0–10
   painQuality: ("krampfend" | "stechend" | "brennend" | "dumpf" | "ziehend" | "anders")[];
   painMapRegionIds: ID[];


### PR DESCRIPTION
## Summary
- add optional painRegions array to capture per-region NRS and qualities
- add optional impactNRS value mirroring overall pain impact

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69079161baec832aa05984906add8542