### PR TITLE
Update default daily entry with new pain fields

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -469,9 +469,16 @@ const parseIsoDate = (iso: string) => {
 
 const createEmptyDailyEntry = (date: string): DailyEntry => ({
   date,
+
+  // Neu
+  painRegions: [], // noch keine Regionen ausgewählt
+  impactNRS: 0, // empfundene Gesamtbeeinträchtigung heute
+
+  // Alt (wird weiter gepflegt, damit Charts usw. funktionieren)
   painNRS: 0,
   painQuality: [],
   painMapRegionIds: [],
+
   bleeding: { isBleeding: false },
   symptoms: {},
   meds: [],


### PR DESCRIPTION
## Summary
- add painRegions and impactNRS defaults to the daily entry factory
- keep legacy pain fields populated alongside the new values

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69079223d810832aa0c11ee14e3e09aa