### PR TITLE
Add migration for pain fields

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1178,6 +1178,28 @@ function normalizeImportedDailyEntry(entry: DailyEntry & Record<string, unknown>
   delete extra["ovulation_pain_side"];
   delete extra["ovulation_pain_intensity"];
 
+  if (!clone.painRegions || clone.painRegions.length === 0) {
+    const regions = Array.isArray(clone.painMapRegionIds) ? clone.painMapRegionIds : [];
+
+    const qualities = Array.isArray(clone.painQuality) ? clone.painQuality : [];
+
+    const perRegion = regions.map((regionId) => ({
+      regionId,
+      nrs: typeof clone.painNRS === "number" ? clone.painNRS : 0,
+      qualities,
+    }));
+
+    if (perRegion.length > 0) {
+      clone.painRegions = perRegion;
+    }
+  }
+
+  if (clone.impactNRS === undefined || clone.impactNRS === null) {
+    if (typeof clone.painNRS === "number") {
+      clone.impactNRS = clone.painNRS;
+    }
+  }
+
   return clone;
 }
 


### PR DESCRIPTION
## Summary
- backfill painRegions when importing legacy entries that only have pain map fields
- copy painNRS into impactNRS for legacy entries that have not captured the new field yet

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690795691810832a93f1acbc5743f0bd