### PR TITLE
Integrate migraine tracking with head pain regions

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -18,7 +18,16 @@ export interface DailyEntry {
 
   impactNRS?: number;
   painNRS: number; // 0–10
-  painQuality: ("krampfend" | "stechend" | "brennend" | "dumpf" | "ziehend" | "anders")[];
+  painQuality: (
+    | "krampfend"
+    | "stechend"
+    | "brennend"
+    | "dumpf"
+    | "ziehend"
+    | "anders"
+    | "Migräne"
+    | "Migräne mit Aura"
+  )[];
   painMapRegionIds: ID[];
   bleeding: {
     isBleeding: boolean;

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -85,7 +85,16 @@ export function validateDailyEntry(entry: DailyEntry): ValidationIssue[] {
     });
   }
 
-  const allowedPainQuality = new Set(["krampfend", "stechend", "brennend", "dumpf", "ziehend", "anders"]);
+  const allowedPainQuality = new Set([
+    "krampfend",
+    "stechend",
+    "brennend",
+    "dumpf",
+    "ziehend",
+    "anders",
+    "Migräne",
+    "Migräne mit Aura",
+  ]);
 
   if (Array.isArray(entry.painRegions) && entry.painRegions.length > 0) {
     entry.painRegions.forEach((region, idx) => {


### PR DESCRIPTION
## Summary
- add migraine and migraine-with-aura selections to the head pain region and keep headache metrics in sync
- derive migraine presence, intensity, and aura from the selected head pain qualities while removing the standalone migraine module UI
- extend shared types and validation rules to accept the new migraine pain qualities

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_6907aa3bcaa0832ab931846ae11d0244