### PR TITLE
Remove headache toggle from typical symptom module

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -978,10 +978,7 @@ const SYMPTOM_MODULE_TOGGLES: Array<{
   key: keyof FeatureFlags;
   label: string;
   term: TermDescriptor;
-}> = [
-  { key: "moduleHeadache", label: "Kopfschmerz/Migräne", term: MODULE_TERMS.headacheOpt.present },
-  { key: "moduleDizziness", label: "Schwindel", term: MODULE_TERMS.dizzinessOpt.present },
-];
+}> = [{ key: "moduleDizziness", label: "Schwindel", term: MODULE_TERMS.dizzinessOpt.present }];
 
 function ModuleToggleRow({
   label,


### PR DESCRIPTION
## Summary
- remove the headache/migraine toggle from the typical endometriosis symptoms module

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6907b87eb770832a948372cac6246fa8