### PR TITLE
Refine slider presentation and value display

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -26,46 +26,49 @@ body {
 
 .endo-slider {
   touch-action: pan-y;
+  transition: background 0.2s ease;
 }
 
 .endo-slider::-webkit-slider-runnable-track {
-  height: 0.75rem;
+  height: 0.5rem;
   border-radius: 9999px;
-  background: #ffe4e6;
+  background: transparent;
 }
 
 .endo-slider::-moz-range-track {
-  height: 0.75rem;
+  height: 0.5rem;
   border-radius: 9999px;
-  background: #ffe4e6;
+  background: rgba(244, 114, 182, 0.16);
 }
 
 .endo-slider::-moz-range-progress {
-  height: 0.75rem;
+  height: 0.5rem;
   border-radius: 9999px;
-  background: var(--endo-accent);
+  background: rgba(225, 29, 72, 0.7);
 }
 
 .endo-slider::-webkit-slider-thumb {
   -webkit-appearance: none;
   appearance: none;
-  width: 2rem;
-  height: 2rem;
+  width: 1.5rem;
+  height: 1.5rem;
   border-radius: 9999px;
-  background: var(--endo-accent);
-  box-shadow: 0 3px 8px rgba(225, 29, 72, 0.28);
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  background: #fff;
+  border: 3px solid var(--endo-accent);
+  box-shadow: 0 12px 25px rgba(225, 29, 72, 0.18);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
   cursor: pointer;
-  margin-top: -0.625rem;
+  margin-top: -0.5rem;
 }
 
 .endo-slider::-moz-range-thumb {
-  width: 2rem;
-  height: 2rem;
+  width: 1.5rem;
+  height: 1.5rem;
   border-radius: 9999px;
-  background: var(--endo-accent);
-  box-shadow: 0 3px 8px rgba(225, 29, 72, 0.28);
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  background: #fff;
+  border: 3px solid var(--endo-accent);
+  box-shadow: 0 12px 25px rgba(225, 29, 72, 0.18);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
   cursor: pointer;
 }
 
@@ -73,8 +76,23 @@ body {
 .endo-slider:focus-visible::-webkit-slider-thumb,
 .endo-slider:active::-moz-range-thumb,
 .endo-slider:focus-visible::-moz-range-thumb {
-  transform: scale(1.05);
-  box-shadow: 0 5px 12px rgba(225, 29, 72, 0.32);
+  transform: scale(1.06);
+  box-shadow: 0 16px 32px rgba(225, 29, 72, 0.24);
+}
+
+.endo-slider:disabled::-webkit-slider-thumb,
+.endo-slider:disabled::-moz-range-thumb {
+  border-color: rgba(148, 163, 184, 0.55);
+  background: #f8fafc;
+  box-shadow: none;
+}
+
+.endo-slider:disabled::-moz-range-track {
+  background: rgba(148, 163, 184, 0.18);
+}
+
+.endo-slider:disabled::-moz-range-progress {
+  background: rgba(148, 163, 184, 0.35);
 }
 
 button:focus-visible,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -863,11 +863,7 @@ function ScoreInput({
           <span>{max}</span>
         </div>
       </div>
-      <SliderValueDisplay
-        value={value}
-        label="Aktueller Wert"
-        className="sm:self-stretch"
-      />
+      <SliderValueDisplay value={value} className="sm:self-stretch" />
     </div>
   );
   if (termKey) {
@@ -996,7 +992,7 @@ function NrsInput({ id, value, onChange }: { id: string; value: number; onChange
           <span>10 Stärkster Schmerz</span>
         </div>
       </div>
-      <SliderValueDisplay value={value} label="Aktueller Wert" className="sm:self-stretch" />
+      <SliderValueDisplay value={value} className="sm:self-stretch" />
     </div>
   );
 }

--- a/app/weekly/components/WeeklyPrompts.tsx
+++ b/app/weekly/components/WeeklyPrompts.tsx
@@ -239,7 +239,6 @@ export function WeeklyPrompts({ value, onChange }: { value: PromptAnswers; onCha
                   <SliderValueDisplay
                     value={value}
                     unit="%"
-                    label="Aktueller Wert"
                     className="min-w-[6rem]"
                     valueClassName="text-3xl"
                   />

--- a/components/ui/slider-value-display.tsx
+++ b/components/ui/slider-value-display.tsx
@@ -18,18 +18,21 @@ export function SliderValueDisplay({
   return (
     <div
       className={cn(
-        "flex min-w-[6rem] flex-col items-center justify-center rounded-xl border border-rose-100 bg-white px-4 py-4 text-rose-700 shadow-sm",
+        "flex min-w-[5rem] flex-col items-center justify-center gap-1 rounded-2xl bg-white/90 px-4 py-3 text-rose-800 shadow-[0_12px_30px_rgba(225,29,72,0.12)] backdrop-blur-sm",
         className,
       )}
       role="status"
       aria-live="polite"
     >
-      {label ? (
-        <span className="text-xs font-semibold uppercase tracking-wide text-rose-500">{label}</span>
-      ) : null}
-      <span className={cn("flex items-baseline gap-1 text-4xl font-semibold", valueClassName)}>
+      {label ? <span className="text-xs font-medium text-rose-500/80">{label}</span> : null}
+      <span
+        className={cn(
+          "flex items-baseline gap-1 text-3xl font-semibold leading-none tracking-tight",
+          valueClassName,
+        )}
+      >
         {value}
-        {unit ? <span className="text-base font-medium text-rose-600">{unit}</span> : null}
+        {unit ? <span className="text-sm font-medium text-rose-500">{unit}</span> : null}
       </span>
     </div>
   );

--- a/components/ui/slider.tsx
+++ b/components/ui/slider.tsx
@@ -1,5 +1,7 @@
 import * as React from "react";
 
+import { cn } from "@/lib/utils";
+
 export interface SliderProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "value" | "defaultValue" | "onChange"> {
   value: number[];
   min?: number;
@@ -8,11 +10,23 @@ export interface SliderProps extends Omit<React.InputHTMLAttributes<HTMLInputEle
   onValueChange?: (value: number[]) => void;
 }
 
-export function Slider({ value, min = 0, max = 100, step = 1, onValueChange, className, style, ...props }: SliderProps) {
+export function Slider({
+  value,
+  min = 0,
+  max = 100,
+  step = 1,
+  onValueChange,
+  className,
+  style,
+  disabled,
+  ...props
+}: SliderProps) {
   const current = value[0] ?? 0;
   const clamped = Math.min(Math.max(current, min), max);
   const range = max - min;
   const percentage = range === 0 ? 0 : ((clamped - min) / range) * 100;
+  const accentColor = disabled ? "rgba(148, 163, 184, 0.55)" : "rgba(225, 29, 72, 0.75)";
+  const trackColor = disabled ? "rgba(148, 163, 184, 0.2)" : "rgba(225, 29, 72, 0.14)";
 
   return (
     <input
@@ -22,12 +36,13 @@ export function Slider({ value, min = 0, max = 100, step = 1, onValueChange, cla
       max={max}
       step={step}
       onChange={(event) => onValueChange?.([Number(event.target.value)])}
-      className={
-        "endo-slider h-3 w-full cursor-pointer appearance-none rounded-full bg-rose-100 accent-rose-500" +
-        (className ? ` ${className}` : "")
-      }
+      disabled={disabled}
+      className={cn(
+        "endo-slider h-2 w-full cursor-pointer appearance-none rounded-full bg-transparent transition focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-rose-200/70 focus-visible:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-80",
+        className,
+      )}
       style={{
-        background: `linear-gradient(to right, var(--endo-accent) 0%, var(--endo-accent) ${percentage}%, #ffe4e6 ${percentage}%, #ffe4e6 100%)`,
+        background: `linear-gradient(90deg, ${accentColor} 0%, ${accentColor} ${percentage}%, ${trackColor} ${percentage}%, ${trackColor} 100%)`,
         ...style,
       }}
       {...props}


### PR DESCRIPTION
## Summary
- restyle the shared slider component and thumb styling for a unified elegant appearance
- simplify slider value displays by removing the "Aktueller Wert" label and border while keeping unit support
- update slider usages to adopt the refreshed styling across weekly prompts and main page inputs

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6907c1410b38832abe62cdf579b47b59