### PR TITLE
feat: add daily check-in overview navigation

### DIFF
--- a/lib/terms.ts
+++ b/lib/terms.ts
@@ -139,6 +139,11 @@ export const TERMS = {
   notesTags: { label: "Schlagworte/Trigger", help: "Kurze Begriffe für Muster & Filter" },
   notesFree: { label: "Notizen", help: "Freier Text für Besonderheiten" },
   urinaryOpt: {
+    present: {
+      label: "Blasensymptome heute?",
+      tech: "Blasensymptome",
+      help: "Gab es Beschwerden wie starken Drang oder Schmerzen?",
+    },
     urgency: {
       label: "Harndrang (0–10)",
       tech: "Dranginkontinenz/LUTS",
@@ -153,6 +158,11 @@ export const TERMS = {
       label: "Nächtliche Toilettengänge",
       tech: "Nykturie",
       help: "Wie oft nachts urinieren?",
+    },
+    padsCount: {
+      label: "Schutzwechsel (Anzahl)",
+      tech: "Anzahl Binden/Slipeinlagen",
+      help: "Wie oft musstest du heute Schutz (Pad/Tampon) wechseln?",
     },
   },
   headacheOpt: {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -67,9 +67,11 @@ export interface DailyEntry {
   };
 
   urinaryOpt?: {
+    present?: boolean;
     urgency?: number;
     leaksCount?: number;
     nocturia?: number;
+    padsCount?: number;
   };
 
   headacheOpt?: {

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -19,9 +19,11 @@ export const zDailyEntry = z
   .object({
     urinaryOpt: z
       .object({
+        present: z.boolean().optional(),
         urgency: zInt01.optional(),
         leaksCount: zNonNeg.optional(),
         nocturia: zNonNeg.optional(),
+        padsCount: zNonNeg.optional(),
       })
       .optional(),
     headacheOpt: z


### PR DESCRIPTION
## Summary
- add a daily check-in overview with category buttons and move the save action there
- track the active daily category to update toolbar labels and reset when leaving the daily view
- show each daily category on its own screen with a completion button to return to the overview

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_690d124f8824832ab4c616b12f6712f7