### PR TITLE
Add overview summaries for completed daily categories

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -82,6 +82,16 @@ const DETAIL_TOOLBAR_FALLBACK_HEIGHT = 96;
 
 type SymptomKey = keyof DailyEntry["symptoms"];
 
+const SYMPTOM_TERMS: Record<SymptomKey, TermDescriptor> = {
+  dysmenorrhea: TERMS.dysmenorrhea,
+  deepDyspareunia: TERMS.deepDyspareunia,
+  pelvicPainNonMenses: TERMS.pelvicPainNonMenses,
+  dyschezia: TERMS.dyschezia,
+  dysuria: TERMS.dysuria,
+  fatigue: TERMS.fatigue,
+  bloating: TERMS.bloating,
+};
+
 interface BeforeInstallPromptEvent extends Event {
   prompt: () => Promise<void>;
   userChoice: Promise<{ outcome: "accepted" | "dismissed"; platform: string }>;
@@ -3973,7 +3983,7 @@ export default function HomePage() {
       const symptomLines: string[] = [];
       if (presentSymptoms.length) {
         const labels = presentSymptoms.map(([key, value]) => {
-          const descriptor = TERMS[key as keyof typeof TERMS];
+          const descriptor = SYMPTOM_TERMS[key];
           const label = descriptor?.label ?? key;
           return typeof value?.score === "number" ? `${label} (${value.score}/10)` : label;
         });


### PR DESCRIPTION
## Summary
- add formatting helpers to create compact summaries for daily check-in data
- render a short "Kurzüberblick" card for each completed category in the daily overview

## Testing
- pnpm lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dbdd8149c832aabcfda8ac5694a52)