### PR TITLE
Restore pain symptom cards in pain section

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -128,13 +128,15 @@ const HEAD_REGION_ID = "head";
 const MIGRAINE_LABEL = "Migräne";
 const MIGRAINE_WITH_AURA_LABEL = "Migräne mit Aura";
 const MIGRAINE_QUALITY_SET = new Set<string>(MIGRAINE_PAIN_QUALITIES);
-const OVULATION_PAIN_SIDES: NonNullable<DailyEntry["ovulationPain"]>["side"][] = [
+type OvulationPainSide = Exclude<NonNullable<DailyEntry["ovulationPain"]>["side"], undefined>;
+
+const OVULATION_PAIN_SIDES: OvulationPainSide[] = [
   "links",
   "rechts",
   "beidseitig",
   "unsicher",
 ];
-const OVULATION_PAIN_SIDE_LABELS: Record<NonNullable<DailyEntry["ovulationPain"]>["side"], string> = {
+const OVULATION_PAIN_SIDE_LABELS: Record<OvulationPainSide, string> = {
   links: "Links",
   rechts: "Rechts",
   beidseitig: "Beidseitig",


### PR DESCRIPTION
## Summary
- add the deep dyspareunia toggle and score card back to the Schmerzen section
- surface ovulation pain inputs in the pain category with side selection and intensity slider
- remove the duplicate intensity controls from the selected-region list and direct users to edit on the body map

## Testing
- pnpm lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dc6de83c8832a813851b76e407851)