### PR TITLE
Reset completed categories on edits and enhance pain summary

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -553,6 +553,12 @@ const TRACKED_DAILY_CATEGORY_IDS: TrackableDailyCategoryId[] = [
   "bowelBladder",
 ];
 
+const createEmptyCategoryCompletion = (): Record<TrackableDailyCategoryId, boolean> =>
+  TRACKED_DAILY_CATEGORY_IDS.reduce((acc, categoryId) => {
+    acc[categoryId] = false;
+    return acc;
+  }, {} as Record<TrackableDailyCategoryId, boolean>);
+
 type SymptomSnapshot = { present: boolean; score: number | null };
 
 type CategorySnapshot = {
@@ -2294,7 +2300,9 @@ export default function HomePage() {
   const dailyDateInputRef = useRef<HTMLInputElement | null>(null);
   const previousDailyDateRef = useRef(dailyDraft.date);
   const previousDailyScopeRef = useRef<string | null>(null);
-  const previousDailyCategoryCompletionRef = useRef<Record<TrackableDailyCategoryId, boolean>>({});
+  const previousDailyCategoryCompletionRef = useRef<Record<TrackableDailyCategoryId, boolean>>(
+    createEmptyCategoryCompletion()
+  );
 
   const isBirthdayGreetingDay = () => {
     const now = new Date();
@@ -4404,12 +4412,12 @@ export default function HomePage() {
     previousDailyScopeRef.current = dailyScopeKey;
     setDailyCategorySnapshots({});
     setDailyCategoryDirtyState({});
-    previousDailyCategoryCompletionRef.current = {} as Record<TrackableDailyCategoryId, boolean>;
+    previousDailyCategoryCompletionRef.current = createEmptyCategoryCompletion();
   }, [dailyScopeKey]);
 
   useEffect(() => {
     if (!dailyScopeKey) {
-      previousDailyCategoryCompletionRef.current = {} as Record<TrackableDailyCategoryId, boolean>;
+      previousDailyCategoryCompletionRef.current = createEmptyCategoryCompletion();
       return;
     }
     const prevCompletion = previousDailyCategoryCompletionRef.current;


### PR DESCRIPTION
## Summary
- reset completed daily categories to incomplete when changes are made and prompt before navigating away
- add snapshot helpers to save or discard category edits when confirming navigation
- include dyspareunia and ovulation pain details in the pain summary and remove the "Ausgewählte Bereiche" module

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690df3565880832a996767eec34bc0ec)