### PR TITLE
Add overview icons for daily category cards

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,7 +11,7 @@ import {
   useRef,
   useState,
 } from "react";
-import type { ChangeEvent, ReactNode } from "react";
+import type { ChangeEvent, ReactNode, SVGProps } from "react";
 import {
   LineChart,
   Line,
@@ -69,6 +69,14 @@ import { cn } from "@/lib/utils";
 import { touchLastActive } from "@/lib/persistence";
 import { usePersistentState } from "@/lib/usePersistentState";
 import WeeklyTabShell from "@/components/weekly/WeeklyTabShell";
+import {
+  BauchIcon,
+  MedicationIcon,
+  PainIcon,
+  PeriodIcon,
+  SleepIcon,
+  SymptomsIcon,
+} from "@/components/icons";
 import {
   listWeeklyReports,
   replaceWeeklyReports,
@@ -4364,31 +4372,41 @@ export default function HomePage() {
           id: "pain" as const,
           title: "Schmerzen",
           description: "Körperkarte, Intensität & Auswirkungen",
+          icon: PainIcon,
           quickActions: [{ label: "Keine Schmerzen", onClick: handleQuickNoPain }],
         },
         {
           id: "symptoms" as const,
           title: "Symptome",
           description: "Typische Endometriose-Symptome dokumentieren",
+          icon: SymptomsIcon,
           quickActions: [{ label: "Keine Symptome", onClick: handleQuickNoSymptoms }],
         },
         {
           id: "bleeding" as const,
           title: "Periode und Blutung",
           description: "Blutung, PBAC-Score & Begleitsymptome",
+          icon: PeriodIcon,
           quickActions: [{ label: "Keine Periode", onClick: handleQuickNoBleeding }],
         },
         {
           id: "medication" as const,
           title: TERMS.meds.label,
           description: "Eingenommene Medikamente & Hilfen",
+          icon: MedicationIcon,
           quickActions: [{ label: "Keine Medikamente", onClick: handleQuickNoMedication }],
         },
-        { id: "sleep" as const, title: "Schlaf", description: "Dauer, Qualität & Aufwachphasen" },
+        {
+          id: "sleep" as const,
+          title: "Schlaf",
+          description: "Dauer, Qualität & Aufwachphasen",
+          icon: SleepIcon,
+        },
         {
           id: "bowelBladder" as const,
           title: "Darm & Blase",
           description: "Verdauung & Blase im Blick behalten",
+          icon: BauchIcon,
         },
         { id: "notes" as const, title: "Notizen & Tags", description: "Freitextnotizen und Tags ergänzen" },
         {
@@ -4400,6 +4418,7 @@ export default function HomePage() {
         id: Exclude<DailyCategoryId, "overview">;
         title: string;
         description: string;
+        icon?: (props: SVGProps<SVGSVGElement>) => JSX.Element;
         quickActions?: Array<{ label: string; onClick: () => void }>;
       }>,
     [handleQuickNoBleeding, handleQuickNoMedication, handleQuickNoPain, handleQuickNoSymptoms]
@@ -5243,6 +5262,13 @@ export default function HomePage() {
                     {dailyCategoryButtons.map((category) => {
                       const isCompleted = dailyCategoryCompletion[category.id] ?? false;
                       const summaryLines = dailyCategorySummaries[category.id] ?? [];
+                      const Icon = category.icon;
+                      const iconWrapperClasses = cn(
+                        "flex h-12 w-12 flex-none items-center justify-center rounded-full border transition",
+                        isCompleted
+                          ? "border-amber-200 bg-amber-100 text-amber-600"
+                          : "border-rose-100 bg-rose-50 text-rose-400 group-hover:border-rose-200 group-hover:bg-rose-100 group-hover:text-rose-500"
+                      );
                       return (
                         <div
                           key={category.id}
@@ -5256,20 +5282,27 @@ export default function HomePage() {
                           <button
                             type="button"
                             onClick={() => setDailyActiveCategory(category.id)}
-                            className="flex w-full items-start justify-between gap-3 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-400 focus-visible:ring-offset-2"
+                            className="flex w-full items-start gap-3 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-400 focus-visible:ring-offset-2"
                           >
-                            <div className="flex-1">
-                              <p className="text-sm font-semibold text-rose-900">{category.title}</p>
-                              <p className="mt-1 text-xs text-rose-600">{category.description}</p>
-                            </div>
-                            <div className="flex items-center gap-2">
-                              {isCompleted ? (
-                                <span className="flex h-6 w-6 items-center justify-center rounded-full bg-emerald-100 text-emerald-600">
-                                  <CheckCircle2 className="h-4 w-4" aria-hidden="true" />
-                                  <span className="sr-only">Bereits abgeschlossen</span>
-                                </span>
-                              ) : null}
-                              <ChevronRight className="h-4 w-4 text-rose-400 transition group-hover:text-rose-500" aria-hidden="true" />
+                            {Icon ? (
+                              <span className={iconWrapperClasses} aria-hidden="true">
+                                <Icon className="h-6 w-6" />
+                              </span>
+                            ) : null}
+                            <div className="flex flex-1 items-start justify-between gap-3">
+                              <div className="flex-1">
+                                <p className="text-sm font-semibold text-rose-900">{category.title}</p>
+                                <p className="mt-1 text-xs text-rose-600">{category.description}</p>
+                              </div>
+                              <div className="flex items-center gap-2">
+                                {isCompleted ? (
+                                  <span className="flex h-6 w-6 items-center justify-center rounded-full bg-emerald-100 text-emerald-600">
+                                    <CheckCircle2 className="h-4 w-4" aria-hidden="true" />
+                                    <span className="sr-only">Bereits abgeschlossen</span>
+                                  </span>
+                                ) : null}
+                                <ChevronRight className="h-4 w-4 text-rose-400 transition group-hover:text-rose-500" aria-hidden="true" />
+                              </div>
                             </div>
                           </button>
                           {category.quickActions?.length ? (

--- a/components/icons.tsx
+++ b/components/icons.tsx
@@ -1,0 +1,126 @@
+import type { SVGProps } from "react";
+
+export function BauchIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 96.91 96.91"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      <circle cx="48.45" cy="48.45" r="48.45" fill="currentColor" fillOpacity={0.2} />
+      <ellipse cx="48.5" cy="64.46" rx="3.02" ry="3.9" fill="currentColor" fillOpacity={0.6} />
+      <ellipse cx="48.5" cy="63.72" rx="4.33" ry="6.61" fill="currentColor" fillOpacity={0.1} />
+    </svg>
+  );
+}
+
+export function MedicationIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 96.91 96.91"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      <circle cx="48.45" cy="48.45" r="48.45" fill="currentColor" fillOpacity={0.2} />
+      <path
+        d="M37.83 44.05c6.13 0 11.11 4.98 11.11 11.11v18.95H26.72V55.16c0-6.13 4.98-11.11 11.11-11.11Z"
+        transform="translate(22.79 127.6) rotate(-135)"
+        fill="currentColor"
+        fillOpacity={0.3}
+      />
+      <path
+        d="M59.08 22.79c6.13 0 11.11 4.98 11.11 11.11v18.95H47.97V33.9c0-6.13 4.98-11.11 11.11-11.11Z"
+        transform="translate(44.05 -30.7) rotate(45)"
+        fill="currentColor"
+        fillOpacity={0.7}
+      />
+    </svg>
+  );
+}
+
+export function PeriodIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 96.91 96.91"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      <circle cx="48.45" cy="48.45" r="48.45" fill="currentColor" fillOpacity={0.2} />
+      <path
+        d="M64.75 53.86c0-9-16.29-34.73-16.29-34.73S32.17 44.86 32.17 53.86s7.3 16.29 16.29 16.29 16.29-7.3 16.29-16.29Z"
+        fill="currentColor"
+        fillOpacity={0.7}
+      />
+    </svg>
+  );
+}
+
+export function SleepIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 96.91 96.91"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      <circle cx="48.45" cy="48.45" r="48.45" fill="currentColor" fillOpacity={0.2} />
+      <path
+        d="M32.31 57.05c-3.29 0-6.57-.45-9.82-1.35-.8-.22-1.27-1.05-1.05-1.84.22-.8 1.05-1.27 1.84-1.05 5.98 1.65 12.06 1.65 18.08 0 .8-.22 1.62.25 1.84 1.05.22.8-.25 1.62-1.05 1.84-3.27.9-6.57 1.34-9.85 1.34Z"
+        fill="currentColor"
+        fillOpacity={0.7}
+      />
+      <path
+        d="M64.56 57.05c-3.29 0-6.57-.45-9.82-1.35-.8-.22-1.27-1.05-1.05-1.84.22-.8 1.05-1.27 1.84-1.05 5.98 1.65 12.06 1.65 18.08 0 .8-.22 1.62.25 1.84 1.05.22.8-.25 1.62-1.05 1.84-3.27.9-6.57 1.34-9.85 1.34Z"
+        fill="currentColor"
+        fillOpacity={0.7}
+      />
+    </svg>
+  );
+}
+
+export function PainIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 96.91 96.91"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      {[48.45, 40, 31.55, 23.1, 14.64, 6.19].map((radius) => (
+        <circle
+          key={radius}
+          cx="48.97"
+          cy="47.94"
+          r={radius}
+          fill="currentColor"
+          fillOpacity={0.2}
+        />
+      ))}
+    </svg>
+  );
+}
+
+export function SymptomsIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 96.91 96.91"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      <circle cx="48.45" cy="48.45" r="48.45" fill="currentColor" fillOpacity={0.2} />
+      <circle cx="39.18" cy="64.48" r="19.78" fill="currentColor" fillOpacity={0.2} />
+      <circle cx="48.45" cy="27.79" r="15.09" fill="currentColor" fillOpacity={0.6} />
+      <circle cx="66.58" cy="44.24" r="19.78" fill="currentColor" fillOpacity={0.2} />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
- convert the public SVG assets into reusable React icon components that inherit colors from context
- display the new icons on the daily overview cards so each main category has a visual marker
- adjust the card layout and styling so icon colors react to completion state

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dfde204f4832ab69fb82edfac9770)