### PR TITLE
Add dizziness summary and bleeding product icons

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -46,6 +46,7 @@ import {
   TrendingUp,
   Upload,
 } from "lucide-react";
+import Image from "next/image";
 
 import { DailyEntry, FeatureFlags, MonthlyEntry } from "@/lib/types";
 import { TERMS } from "@/lib/terms";
@@ -487,12 +488,54 @@ const SYMPTOM_ITEMS: { key: SymptomKey; termKey: TermKey }[] = [
 ];
 
 const PBAC_PRODUCT_ITEMS = [
-  { id: "pad_light", label: "Binde – leicht", score: 1, product: "pad", saturation: "light" },
-  { id: "pad_medium", label: "Binde – mittel", score: 5, product: "pad", saturation: "medium" },
-  { id: "pad_heavy", label: "Binde – stark", score: 20, product: "pad", saturation: "heavy" },
-  { id: "tampon_light", label: "Tampon – leicht", score: 1, product: "tampon", saturation: "light" },
-  { id: "tampon_medium", label: "Tampon – mittel", score: 5, product: "tampon", saturation: "medium" },
-  { id: "tampon_heavy", label: "Tampon – stark", score: 10, product: "tampon", saturation: "heavy" },
+  {
+    id: "pad_light",
+    label: "Binde – leicht",
+    score: 1,
+    product: "pad",
+    saturation: "light",
+    icon: "/icons/binde-low.svg",
+  },
+  {
+    id: "pad_medium",
+    label: "Binde – mittel",
+    score: 5,
+    product: "pad",
+    saturation: "medium",
+    icon: "/icons/binde-mid.svg",
+  },
+  {
+    id: "pad_heavy",
+    label: "Binde – stark",
+    score: 20,
+    product: "pad",
+    saturation: "heavy",
+    icon: "/icons/binde-max.svg",
+  },
+  {
+    id: "tampon_light",
+    label: "Tampon – leicht",
+    score: 1,
+    product: "tampon",
+    saturation: "light",
+    icon: "/icons/tampon-low.svg",
+  },
+  {
+    id: "tampon_medium",
+    label: "Tampon – mittel",
+    score: 5,
+    product: "tampon",
+    saturation: "medium",
+    icon: "/icons/tampon-mid.svg",
+  },
+  {
+    id: "tampon_heavy",
+    label: "Tampon – stark",
+    score: 10,
+    product: "tampon",
+    saturation: "heavy",
+    icon: "/icons/tampon-max.svg",
+  },
 ] as const;
 
 const PBAC_CLOT_ITEMS = [
@@ -4819,12 +4862,25 @@ export default function HomePage() {
       ]>;
       const presentSymptoms = symptomEntries.filter(([, value]) => value?.present);
       const symptomLines: string[] = [];
-      if (presentSymptoms.length) {
-        const labels = presentSymptoms.map(([key, value]) => {
-          const descriptor = SYMPTOM_TERMS[key];
-          const label = descriptor?.label ?? key;
-          return typeof value?.score === "number" ? `${label} (${value.score}/10)` : label;
-        });
+      const labels = presentSymptoms.map(([key, value]) => {
+        const descriptor = SYMPTOM_TERMS[key];
+        const label = descriptor?.label ?? key;
+        return typeof value?.score === "number" ? `${label} (${value.score}/10)` : label;
+      });
+      if (entry.dizzinessOpt?.present) {
+        const dizzinessDetails: string[] = [];
+        if (typeof entry.dizzinessOpt.nrs === "number") {
+          dizzinessDetails.push(`${formatNumber(entry.dizzinessOpt.nrs, { maximumFractionDigits: 1 })}/10`);
+        }
+        if (entry.dizzinessOpt.orthostatic) {
+          dizzinessDetails.push(MODULE_TERMS.dizzinessOpt.orthostatic.label);
+        }
+        const dizzinessLabel = dizzinessDetails.length
+          ? `${MODULE_TERMS.dizzinessOpt.present.label} (${dizzinessDetails.join(", ")})`
+          : MODULE_TERMS.dizzinessOpt.present.label;
+        labels.push(dizzinessLabel);
+      }
+      if (labels.length) {
         symptomLines.push(`Vorhanden: ${formatList(labels, 3)}`);
       } else {
         symptomLines.push(`${pickRandom(SYMPTOM_FREE_MESSAGES)} ${pickRandom(SYMPTOM_FREE_EMOJIS)}`);
@@ -5407,7 +5463,7 @@ export default function HomePage() {
                           >
                             {Icon ? (
                               <span className={iconWrapperClasses} aria-hidden="true">
-                                <Icon className="h-8 w-8" />
+                                <Icon className="h-full w-full" />
                               </span>
                             ) : null}
                             <div className="flex flex-1 items-start justify-between gap-3">
@@ -5906,6 +5962,16 @@ export default function HomePage() {
                                 tech={TERMS.pbac.tech}
                                 help={TERMS.pbac.help}
                                 htmlFor={sliderId}
+                                meta={
+                                  <span className="flex h-10 w-10 items-center justify-center rounded-full border border-rose-200 bg-white">
+                                    <Image
+                                      src={item.icon}
+                                      alt={item.label}
+                                      width={40}
+                                      height={40}
+                                    />
+                                  </span>
+                                }
                               >
                                 <div className="space-y-2">
                                   <Slider

--- a/public/icons/binde-low.svg
+++ b/public/icons/binde-low.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img">
+  <circle cx="32" cy="32" r="32" fill="#fce7f3" />
+  <rect x="20" y="10" width="24" height="44" rx="12" fill="#ffffff" stroke="#f43f5e" stroke-width="2" />
+  <rect x="24" y="36" width="16" height="12" rx="8" fill="#fecdd3" />
+  <rect x="26" y="24" width="12" height="16" rx="6" fill="#fde8eb" />
+</svg>

--- a/public/icons/binde-max.svg
+++ b/public/icons/binde-max.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img">
+  <circle cx="32" cy="32" r="32" fill="#f9a8d4" />
+  <rect x="20" y="10" width="24" height="44" rx="12" fill="#ffffff" stroke="#f43f5e" stroke-width="2" />
+  <rect x="24" y="24" width="16" height="24" rx="8" fill="#fb7185" />
+  <rect x="26" y="14" width="12" height="14" rx="6" fill="#fda4af" />
+</svg>

--- a/public/icons/binde-mid.svg
+++ b/public/icons/binde-mid.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img">
+  <circle cx="32" cy="32" r="32" fill="#fbcfe8" />
+  <rect x="20" y="10" width="24" height="44" rx="12" fill="#ffffff" stroke="#f43f5e" stroke-width="2" />
+  <rect x="24" y="30" width="16" height="18" rx="8" fill="#fda4af" />
+  <rect x="26" y="18" width="12" height="16" rx="6" fill="#fecdd3" />
+</svg>

--- a/public/icons/tampon-low.svg
+++ b/public/icons/tampon-low.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img">
+  <circle cx="32" cy="32" r="32" fill="#fce7f3" />
+  <rect x="26" y="12" width="12" height="34" rx="6" fill="#ffffff" stroke="#f43f5e" stroke-width="2" />
+  <rect x="28" y="30" width="8" height="12" rx="4" fill="#fecdd3" />
+  <path d="M32 46c0 4 3 6 6 6" stroke="#fb7185" stroke-width="2" stroke-linecap="round" fill="none" />
+</svg>

--- a/public/icons/tampon-max.svg
+++ b/public/icons/tampon-max.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img">
+  <circle cx="32" cy="32" r="32" fill="#f9a8d4" />
+  <rect x="26" y="12" width="12" height="34" rx="6" fill="#ffffff" stroke="#f43f5e" stroke-width="2" />
+  <rect x="28" y="22" width="8" height="20" rx="4" fill="#fb7185" />
+  <path d="M32 46c0 5 4 8 9 9" stroke="#fb7185" stroke-width="2" stroke-linecap="round" fill="none" />
+</svg>

--- a/public/icons/tampon-mid.svg
+++ b/public/icons/tampon-mid.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img">
+  <circle cx="32" cy="32" r="32" fill="#fbcfe8" />
+  <rect x="26" y="12" width="12" height="34" rx="6" fill="#ffffff" stroke="#f43f5e" stroke-width="2" />
+  <rect x="28" y="26" width="8" height="16" rx="4" fill="#fda4af" />
+  <path d="M32 46c0 4 3 6 7 7" stroke="#fb7185" stroke-width="2" stroke-linecap="round" fill="none" />
+</svg>


### PR DESCRIPTION
## Summary
- add the dizziness module to the symptoms quick summary
- render PBAC product icons with new assets while matching category icon sizing
- include new pad and tampon absorbency SVGs for bleeding strength visuals

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e10a8d044832a8f2762560272646d)