### PR TITLE
Update bleeding defaults and category icons

### DIFF
--- a/components/icons.tsx
+++ b/components/icons.tsx
@@ -51,6 +51,7 @@ export function PeriodIcon(props: SVGProps<SVGSVGElement>) {
       focusable="false"
       {...props}
     >
+      <circle cx="48.45" cy="48.45" r="48.45" fill="#fff" />
       <circle cx="48.45" cy="48.45" r="48.45" fill="currentColor" fillOpacity={0.2} />
       <path
         d="M64.75 53.86c0-9-16.29-34.73-16.29-34.73S32.17 44.86 32.17 53.86s7.3 16.29 16.29 16.29 16.29-7.3 16.29-16.29Z"
@@ -121,6 +122,73 @@ export function SymptomsIcon(props: SVGProps<SVGSVGElement>) {
       <circle cx="39.18" cy="64.48" r="19.78" fill="currentColor" fillOpacity={0.2} />
       <circle cx="48.45" cy="27.79" r="15.09" fill="currentColor" fillOpacity={0.6} />
       <circle cx="66.58" cy="44.24" r="19.78" fill="currentColor" fillOpacity={0.2} />
+    </svg>
+  );
+}
+
+export function NotesTagsIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 96.91 96.91"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      <circle cx="48.45" cy="48.45" r="48.45" fill="#fff" />
+      <circle cx="48.45" cy="48.45" r="48.45" fill="currentColor" fillOpacity={0.15} />
+      <path
+        d="M64.63 19.46H34.58c-3.45 0-6.27 2.69-6.49 6.08h-.74c-1.28 0-2.31 1.03-2.31 2.31s1.03 2.31 2.31 2.31h.72v3.64h-.72c-1.28 0-2.31 1.03-2.31 2.31s1.03 2.31 2.31 2.31h.72v3.64h-.72c-1.28 0-2.31 1.03-2.31 2.31s1.03 2.31 2.31 2.31h.72v3.64h-.72c-1.28 0-2.31 1.03-2.31 2.31s1.03 2.31 2.31 2.31h.72v3.64h-.72c-1.28 0-2.31 1.03-2.31 2.31s1.03 2.31 2.31 2.31h.72v3.64h-.72c-1.28 0-2.31 1.03-2.31 2.31s1.03 2.31 2.31 2.31h.74c.22 3.4 3.04 6.08 6.49 6.08h30.05c3.6 0 6.51-2.92 6.51-6.51V25.97c0-3.6-2.92-6.51-6.51-6.51Z"
+        fill="currentColor"
+        fillOpacity={0.7}
+      />
+      <path
+        d="M79.5 67.52c-2.42 0-4.38-1.96-4.38-4.38V36.72c0-.72.17-1.44.48-2.09l2.81-5.74c.54-.73 1.63-.73 2.17 0l2.81 5.74c.32.65.48 1.37.48 2.09v26.42c0 2.42-1.96 4.38-4.38 4.38Z"
+        fill="currentColor"
+        fillOpacity={0.48}
+      />
+      <path
+        d="M79.5 37.05c1.55 0 3.02-.37 4.32-1.01-.07-.49-.21-.96-.43-1.41l-2.81-5.74c-.54-.73-1.63-.73-2.17 0l-2.81 5.74c-.22.45-.36.92-.43 1.41 1.31.64 2.77 1.01 4.32 1.01Z"
+        fill="currentColor"
+        fillOpacity={0.12}
+      />
+      <path
+        d="M79.5 30.06c.53 0 1.03-.16 1.45-.41l-.37-.75c-.54-.73-1.63-.73-2.17 0l-.37.75c.43.26.92.41 1.45.41Z"
+        fill="#fff"
+      />
+    </svg>
+  );
+}
+
+export function OptionalValuesIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 96.91 96.91"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      <circle cx="48.45" cy="48.45" r="48.45" fill="#fff" />
+      <circle cx="48.45" cy="48.45" r="48.45" fill="currentColor" fillOpacity={0.15} />
+      <rect
+        x="43.29"
+        y="29.07"
+        width="10.32"
+        height="38.78"
+        rx="2.65"
+        ry="2.65"
+        fill="currentColor"
+      />
+      <rect
+        x="29.07"
+        y="43.29"
+        width="38.78"
+        height="10.32"
+        rx="2.65"
+        ry="2.65"
+        fill="currentColor"
+      />
     </svg>
   );
 }


### PR DESCRIPTION
## Summary
- add white backdrops to the bleeding category visuals so transparent areas render white
- carry over the previous day's "Periode aktiv?" setting when opening a new entry
- swap the notes/tags and optional values buttons to use the new SVG icons

## Testing
- pnpm lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e7593b80c832aac8168cc7ca2128a)