### PR TITLE
Fix analytics crash when legacy entries lack bleeding data

### DIFF
--- a/lib/dailyEntries.test.ts
+++ b/lib/dailyEntries.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeDailyEntry } from "./dailyEntries";
+import type { DailyEntry } from "./types";
+
+describe("normalizeDailyEntry", () => {
+  it("fills bleeding defaults for legacy entries", () => {
+    const legacyEntry = {
+      date: "2024-01-01",
+      painNRS: 0,
+      painQuality: [],
+      painMapRegionIds: [],
+      symptoms: {},
+      meds: [],
+    } as unknown as DailyEntry;
+
+    const normalized = normalizeDailyEntry(legacyEntry);
+
+    expect(normalized.bleeding).toEqual({ isBleeding: false });
+    expect(normalized.meds).toEqual([]);
+    expect(normalized.symptoms).toEqual({});
+    expect(normalized.painRegions).toEqual([]);
+  });
+
+  it("returns the same reference when no normalization is needed", () => {
+    const entry: DailyEntry = {
+      date: "2024-02-01",
+      painNRS: 1,
+      painQuality: [],
+      painMapRegionIds: [],
+      painRegions: [],
+      bleeding: { isBleeding: true, pbacScore: 12 },
+      symptoms: {},
+      meds: [],
+    };
+
+    const normalized = normalizeDailyEntry(entry);
+
+    expect(normalized).toBe(entry);
+  });
+});

--- a/lib/dailyEntries.ts
+++ b/lib/dailyEntries.ts
@@ -1,0 +1,52 @@
+import type { DailyEntry } from "./types";
+
+export function normalizeDailyEntry(entry: DailyEntry): DailyEntry {
+  const bleedingSource = (entry as Partial<DailyEntry>).bleeding;
+  const hasValidBleeding = typeof bleedingSource?.isBleeding === "boolean";
+  const needsPainRegionsNormalization = !Array.isArray(entry.painRegions);
+  const needsPainQualityNormalization = !Array.isArray(entry.painQuality);
+  const needsPainMapIdsNormalization = !Array.isArray(entry.painMapRegionIds);
+  const needsMedsNormalization = !Array.isArray(entry.meds);
+  const needsSymptomsNormalization = entry.symptoms === undefined;
+
+  if (
+    hasValidBleeding &&
+    !needsPainRegionsNormalization &&
+    !needsPainQualityNormalization &&
+    !needsPainMapIdsNormalization &&
+    !needsMedsNormalization &&
+    !needsSymptomsNormalization
+  ) {
+    return entry;
+  }
+
+  const normalizedBleeding: DailyEntry["bleeding"] = {
+    isBleeding: Boolean(bleedingSource?.isBleeding),
+  };
+
+  if (typeof bleedingSource?.pbacScore === "number" && Number.isFinite(bleedingSource.pbacScore)) {
+    normalizedBleeding.pbacScore = bleedingSource.pbacScore;
+  }
+  if (typeof bleedingSource?.clots === "boolean") {
+    normalizedBleeding.clots = bleedingSource.clots;
+  }
+  if (typeof bleedingSource?.flooding === "boolean") {
+    normalizedBleeding.flooding = bleedingSource.flooding;
+  }
+
+  const painRegions = Array.isArray(entry.painRegions) ? entry.painRegions : [];
+  const painQuality = Array.isArray(entry.painQuality) ? entry.painQuality : [];
+  const painMapRegionIds = Array.isArray(entry.painMapRegionIds) ? entry.painMapRegionIds : [];
+  const meds = Array.isArray(entry.meds) ? entry.meds : [];
+  const symptoms = entry.symptoms ?? {};
+
+  return {
+    ...entry,
+    bleeding: normalizedBleeding,
+    painRegions,
+    painQuality,
+    painMapRegionIds,
+    meds,
+    symptoms,
+  };
+}


### PR DESCRIPTION
## Summary
- add a normalization helper to restore missing bleeding data on legacy daily entries and keep array fields well-formed
- ensure imported and persisted entries run through normalization before analytics logic executes
- cover the normalization behaviour with a dedicated unit test

## Testing
- npx vitest run lib/dailyEntries.test.ts --environment node

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69164e553118832a8c3bafcfe4f9b36a)