### PR TITLE
Ensure trend chart ends at today and highlight today in overview

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4144,18 +4144,29 @@ export default function HomePage() {
     return formatDate(threshold);
   }, [todayDate]);
 
+  type PainTrendDatum = {
+    date: string;
+    cycleDay: number | null;
+    cycleLabel: string;
+    weekday: string;
+    pain: number | null;
+    pbac: number | null;
+    symptomAverage: number | null;
+    sleepQuality: number | null;
+  };
+
   const { painTrendData, painTrendCycleStarts } = useMemo(() => {
     const thresholdIso = trendWindowStartIso;
     const filteredEntries = thresholdIso
       ? annotatedDailyEntries.filter(({ entry }) => entry.date >= thresholdIso)
       : annotatedDailyEntries;
     const effectiveEntries = filteredEntries.length > 0 ? filteredEntries : annotatedDailyEntries;
-    const mapped = effectiveEntries.map(({ entry, cycleDay, weekday, symptomAverage }) => ({
+    const mapped: PainTrendDatum[] = effectiveEntries.map(({ entry, cycleDay, weekday, symptomAverage }) => ({
       date: entry.date,
       cycleDay,
       cycleLabel: cycleDay ? `ZT ${cycleDay}` : "–",
       weekday,
-      pain: entry.painNRS,
+      pain: entry.painNRS ?? null,
       pbac: entry.bleeding.pbacScore ?? null,
       symptomAverage,
       sleepQuality: entry.sleep?.quality ?? null,


### PR DESCRIPTION
## Summary
- ensure the home trend dataset always includes the current day so the chart reaches today
- highlight the selected date as "Heute" in the daily overview when it matches the current date

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691662d2dc20832a933b81763e9b117f)