### PR TITLE
Ensure home trend chart covers last 30 days

### DIFF
--- a/lib/date.ts
+++ b/lib/date.ts
@@ -1,0 +1,14 @@
+export const formatDate = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, "0");
+  const day = `${date.getDate()}`.padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+export const parseIsoDate = (iso: string): Date | null => {
+  const [year, month, day] = iso.split("-").map(Number);
+  if (!year || !month || !day) {
+    return null;
+  }
+  return new Date(year, month - 1, day);
+};

--- a/lib/trends/painTrend.test.ts
+++ b/lib/trends/painTrend.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+
+import { formatDate, parseIsoDate } from "@/lib/date";
+import type { DailyEntry } from "@/lib/types";
+import {
+  buildPainTrendSeries,
+  LAST_TREND_WINDOW_DAYS,
+  type AnnotatedDailyEntryForTrend,
+} from "@/lib/trends/painTrend";
+
+const createDailyEntry = (
+  iso: string,
+  overrides: Partial<DailyEntry> = {}
+): DailyEntry => ({
+  date: iso,
+  painRegions: overrides.painRegions ?? [],
+  impactNRS: overrides.impactNRS ?? 0,
+  painNRS: overrides.painNRS ?? 0,
+  painQuality: overrides.painQuality ?? [],
+  painMapRegionIds: overrides.painMapRegionIds ?? [],
+  bleeding:
+    overrides.bleeding ?? {
+      isBleeding: false,
+    },
+  symptoms: overrides.symptoms ?? {},
+  meds: overrides.meds ?? [],
+  rescueDosesCount: overrides.rescueDosesCount,
+  sleep: overrides.sleep,
+  gi: overrides.gi,
+  urinary: overrides.urinary,
+  activity: overrides.activity,
+  exploratory: overrides.exploratory,
+  ovulation: overrides.ovulation,
+  ovulationPain: overrides.ovulationPain,
+  urinaryOpt: overrides.urinaryOpt,
+  headacheOpt: overrides.headacheOpt,
+  dizzinessOpt: overrides.dizzinessOpt,
+  notesTags: overrides.notesTags,
+  notesFree: overrides.notesFree,
+});
+
+describe("buildPainTrendSeries", () => {
+  const todayIso = "2024-03-30";
+  const todayDate = parseIsoDate(todayIso)!;
+
+  const annotatedEntries: AnnotatedDailyEntryForTrend[] = [
+    {
+      entry: createDailyEntry(todayIso, {
+        painNRS: 6,
+        bleeding: { isBleeding: true, pbacScore: 120 },
+        sleep: { quality: 4 },
+      }),
+      cycleDay: 1,
+      weekday: "Sa",
+      symptomAverage: 2.5,
+    },
+    {
+      entry: createDailyEntry("2024-03-27", {
+        painNRS: 3,
+        bleeding: { isBleeding: false },
+      }),
+      cycleDay: 28,
+      weekday: "Mi",
+      symptomAverage: null,
+    },
+  ];
+
+  it("returns exactly 30 days ending today", () => {
+    const { data } = buildPainTrendSeries(annotatedEntries, todayDate);
+    expect(data).toHaveLength(LAST_TREND_WINDOW_DAYS);
+    const expectedStart = new Date(todayDate.getTime());
+    expectedStart.setDate(expectedStart.getDate() - (LAST_TREND_WINDOW_DAYS - 1));
+    expect(data[0].date).toBe(formatDate(expectedStart));
+    expect(data[data.length - 1].date).toBe(todayIso);
+    expect(new Set(data.map((item) => item.date)).size).toBe(LAST_TREND_WINDOW_DAYS);
+  });
+
+  it("fills missing days with placeholders", () => {
+    const { data } = buildPainTrendSeries(annotatedEntries, todayDate);
+    const placeholder = data.find((item) => item.date === "2024-03-28");
+    expect(placeholder).toBeDefined();
+    expect(placeholder?.pain).toBeNull();
+    expect(placeholder?.pbac).toBeNull();
+    expect(placeholder?.cycleLabel).toBe("–");
+  });
+
+  it("marks cycle starts and preserves recorded metrics", () => {
+    const { data, cycleStarts } = buildPainTrendSeries(annotatedEntries, todayDate);
+    const todayEntry = data.find((item) => item.date === todayIso);
+    expect(todayEntry?.pain).toBe(6);
+    expect(todayEntry?.pbac).toBe(120);
+    expect(todayEntry?.sleepQuality).toBe(4);
+    expect(todayEntry?.symptomAverage).toBe(2.5);
+    expect(cycleStarts.map((item) => item.date)).toContain(todayIso);
+  });
+});

--- a/lib/trends/painTrend.ts
+++ b/lib/trends/painTrend.ts
@@ -1,0 +1,61 @@
+import type { DailyEntry } from "@/lib/types";
+import { formatDate } from "@/lib/date";
+
+export type PainTrendDatum = {
+  date: string;
+  cycleDay: number | null;
+  cycleLabel: string;
+  weekday: string;
+  pain: number | null;
+  pbac: number | null;
+  symptomAverage: number | null;
+  sleepQuality: number | null;
+};
+
+export type AnnotatedDailyEntryForTrend = {
+  entry: DailyEntry;
+  cycleDay: number | null;
+  weekday: string;
+  symptomAverage: number | null;
+};
+
+export const LAST_TREND_WINDOW_DAYS = 30;
+const WEEKDAY_LOCALE = "de-DE";
+
+export function buildPainTrendSeries(
+  annotatedEntries: AnnotatedDailyEntryForTrend[],
+  todayDate: Date
+): { data: PainTrendDatum[]; cycleStarts: PainTrendDatum[] } {
+  const annotatedByDate = new Map(
+    annotatedEntries.map((item) => [item.entry.date, item] as const)
+  );
+
+  const data: PainTrendDatum[] = [];
+  for (let offset = LAST_TREND_WINDOW_DAYS - 1; offset >= 0; offset -= 1) {
+    const current = new Date(todayDate.getTime());
+    current.setDate(current.getDate() - offset);
+    const iso = formatDate(current);
+    const annotated = annotatedByDate.get(iso);
+    const cycleDay = annotated?.cycleDay ?? null;
+    const painNrs = annotated?.entry.painNRS;
+    const pbacScore = annotated?.entry.bleeding.pbacScore;
+    const symptomAverage = annotated?.symptomAverage;
+    const sleepQuality = annotated?.entry.sleep?.quality;
+
+    data.push({
+      date: iso,
+      cycleDay,
+      cycleLabel: cycleDay ? `ZT ${cycleDay}` : "–",
+      weekday: current.toLocaleDateString(WEEKDAY_LOCALE, { weekday: "short" }),
+      pain: typeof painNrs === "number" ? painNrs : null,
+      pbac: typeof pbacScore === "number" ? pbacScore : null,
+      symptomAverage: typeof symptomAverage === "number" ? symptomAverage : null,
+      sleepQuality: typeof sleepQuality === "number" ? sleepQuality : null,
+    });
+  }
+
+  return {
+    data,
+    cycleStarts: data.filter((item) => item.cycleDay === 1),
+  };
+}


### PR DESCRIPTION
## Summary
- lock the home trend chart window to the last 30 calendar days ending today
- synthesize placeholder entries for missing days to keep the x-axis spacing consistent
- make the trend tooltip tolerant of empty pain values

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916f71c2de8832a97727b74b0bf852c)